### PR TITLE
Allow omit leading --- in front matter

### DIFF
--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -28,16 +28,19 @@ getDate = (date = new Date()) ->
   seconds: ("0" + date.getSeconds()).slice(-2)
 
 FRONT_MATTER_REGEX = ///
-  ^---\s*       # match open ---
+  ^(---\s*)?    # match open ---
   ([\s\S]*?)\s* # match anything \s and \S
   ---\s*$       # match ending ---
   ///m
 
 hasFrontMatter = (content) ->
-  FRONT_MATTER_REGEX.test(content)
+  matchResult = content.match(FRONT_MATTER_REGEX)
+  return false unless matchResult?
+  frontMatter = yaml.safeLoad(matchResult[2].trim())
+  frontMatter? and typeof frontMatter is 'object'
 
 getFrontMatter = (content) ->
-  yamlText = content.match(FRONT_MATTER_REGEX)[1].trim()
+  yamlText = content.match(FRONT_MATTER_REGEX)[2].trim()
   return yaml.safeLoad(yamlText) || {}
 
 getFrontMatterText = (obj) ->

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -78,9 +78,12 @@ Markdown (or Textile), Liquid, HTML & CSS go in.
       id: "id", text: "text", url: "http://jekyll.com", title: "Jekyll Website"
 
   it "test whether has front matter", ->
-    fixture = "abc\n---\nhello world\n"
+    fixture = "title\n---\nhello world\n"
+    console.log utils.hasFrontMatter(fixture)
     expect(utils.hasFrontMatter(fixture)).toBe(false)
     fixture = "---\nkey1: val1\nkey2: val2\n---\n"
+    expect(utils.hasFrontMatter(fixture)).toBe(true)
+    fixture = "key1: val1\nkey2: val2\n---\n"
     expect(utils.hasFrontMatter(fixture)).toBe(true)
 
   it "get front matter as js object", ->


### PR DESCRIPTION
To enable markdown writer recognize front matter properly even when leading "---" is omitted
