### PR TITLE
[add] file name with/ without date by config

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,6 +7,7 @@ module.exports =
     urlForPosts: "http://example.github.io/assets/posts.json"
     urlForCategories: "http://example.github.io/assets/categories.json"
     fileExtension: ".markdown"
+    checkedForHexo: false
 
   activate: (state) ->
     # general

--- a/lib/new-post-view.coffee
+++ b/lib/new-post-view.coffee
@@ -71,10 +71,10 @@ class NewPostView extends View
     return path.join(@pathEditor.getText(), @getFileName())
 
   getFileName: ->
-    date = @dateEditor.getText()
+    date = if atom.config.get("markdown-writer.checkedForHexo") then "" else "#{@dateEditor.getText()}-"
     title = utils.dasherize(@titleEditor.getText() || "new post")
     extension = atom.config.get("markdown-writer.fileExtension")
-    return "#{date}-#{title}#{extension}"
+    return "#{date}#{title}#{extension}"
 
   getFrontMatter: ->
     layout: "post"

--- a/spec/new-post-view-spec.coffee
+++ b/spec/new-post-view-spec.coffee
@@ -1,5 +1,6 @@
 {WorkspaceView} = require "atom"
 NewPostView = require "../lib/new-post-view"
+utils = require "../lib/utils"
 
 describe "NewPostView", ->
   beforeEach ->
@@ -30,3 +31,14 @@ date: "2014-11-19"
     atom.config.set("markdown-writer.frontMatter", "title: <title>")
     expect(@view.generateFrontMatter(frontMatter))
       .toEqual("title: the actual title")
+
+  it "return file name with Date", ->
+    @view.dateEditor.setText(utils.getDateStr())
+    expect(@view.getFileName())
+      .toMatch(/^\d{4}-\d{1,2}-\d{1,2}/)
+
+  it "return file name without Date", ->
+    atom.config.set("markdown-writer.checkedForHexo", true)
+    @view.dateEditor.setText(utils.getDateStr())
+    expect(@view.getFileName())
+      .not.toMatch(/^\d{4}-\d{1,2}-\d{1,2}/)


### PR DESCRIPTION
The date string in file name isn't necessary for Hexo , and `hexo new`
command never add date automatically. So adding date or not by
configuration is the better way, I think.
