### PR TITLE
  fix wrong cursor position when insert empty style 

### DIFF
--- a/keymaps/keymap.cson
+++ b/keymaps/keymap.cson
@@ -34,6 +34,7 @@
   "ctrl-i":       "markdown-writer:toggle-italic-text"
   "ctrl-b":       "markdown-writer:toggle-bold-text"
   "ctrl-'":       "markdown-writer:toggle-code-text"
+  'ctrl-`':       "markdown-writer:toggle-codeblock-text"
   "ctrl-h":       "markdown-writer:toggle-strikethrough-text"
   "ctrl-1":       "markdown-writer:toggle-h1"
   "ctrl-2":       "markdown-writer:toggle-h2"

--- a/lib/style-text.coffee
+++ b/lib/style-text.coffee
@@ -36,10 +36,10 @@ class StyleText
     selection.insertText(text)
 
   insertEmptyStyle: (selection) ->
-    selection.insertText(@addStyle(""))
+    selection.insertText(@style.before)
     {row, column} = selection.cursor.getBufferPosition()
-    selection.cursor.setBufferPosition([row, column - @style.after.length])
-
+    selection.insertText(@style.after)
+    selection.cursor.setBufferPosition([row, column])
   isStyleOn: (text) ->
     @getStylePattern().test(text) if text
 


### PR DESCRIPTION
If there is a '\n' in a style's {after} property, the cursor will be at a wrong line (below the right one) after insertion.
For example, inserting a codeblock will leave the cursor at the last line together with '\`\`\`'.

After this fix, the cursor will be between the two lines of '\`\`\`', namely, in the middle.