### PR TITLE
Fixed front-matter import in publish-draft command

### DIFF
--- a/lib/publish-draft.coffee
+++ b/lib/publish-draft.coffee
@@ -1,5 +1,5 @@
 {$} = require "atom-space-pen-views"
-FrontMatter = require "./models/front-matter"
+FrontMatter = require "./front-matter"
 config = require "./config"
 utils = require "./utils"
 fs = require "fs-plus"


### PR DESCRIPTION
Publish command was not working, throwing the require error. This simple import fix does the trick for me!

Atom 1.0.9
Linux Ubuntu 15.04