### PR TITLE
Fix autocompleteplus conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+* Abort key mapping event if action not performable
+* Fix key mapping conflicts with `autocomplete-plus`
+
 ## 2.1.0
 
 * Add default project support directory

--- a/keymaps/keymap.cson
+++ b/keymaps/keymap.cson
@@ -3,10 +3,10 @@
 # To create additional keymaps, run command `Markdown Writer: Create Default Keymaps`
 # Refer to wiki: https://github.com/zhuochun/md-writer/wiki/Settings-for-Keymaps
 
-"atom-workspace atom-text-editor:not([mini])[data-grammar~='gfm']":
+"atom-workspace atom-text-editor:not([mini])":
   "enter": "markdown-writer:insert-new-line"
-  "tab"  : "markdown-writer:indent-list-line"
+  "tab":   "markdown-writer:indent-list-line"
 
 ".markdown-writer atom-text-editor[mini]":
-  "enter" : "core:confirm"
+  "enter":  "core:confirm"
   "escape": "core:cancel"

--- a/keymaps/sample-linux.cson
+++ b/keymaps/sample-linux.cson
@@ -4,7 +4,7 @@
 #
 # Wiki: https://github.com/zhuochun/md-writer/wiki/Settings-for-Keymaps
 #
-".platform-linux atom-text-editor:not([mini])[data-grammar~='gfm']":
+".platform-linux atom-text-editor:not([mini])":
   "shift-ctrl-K": "markdown-writer:insert-link"
   "shift-ctrl-I": "markdown-writer:insert-image"
   "ctrl-i":       "markdown-writer:toggle-italic-text"

--- a/keymaps/sample-osx.cson
+++ b/keymaps/sample-osx.cson
@@ -4,7 +4,7 @@
 #
 # Wiki: https://github.com/zhuochun/md-writer/wiki/Settings-for-Keymaps
 #
-".platform-darwin atom-text-editor:not([mini])[data-grammar~='gfm']":
+".platform-darwin atom-text-editor:not([mini])":
   "shift-cmd-K": "markdown-writer:insert-link"
   "shift-cmd-I": "markdown-writer:insert-image"
   "cmd-i":       "markdown-writer:toggle-italic-text"

--- a/keymaps/sample-win32.cson
+++ b/keymaps/sample-win32.cson
@@ -4,7 +4,7 @@
 #
 # Wiki: https://github.com/zhuochun/md-writer/wiki/Settings-for-Keymaps
 #
-".platform-win32 atom-text-editor:not([mini])[data-grammar~='gfm']":
+".platform-win32 atom-text-editor:not([mini])":
   "shift-ctrl-K": "markdown-writer:insert-link"
   "shift-ctrl-I": "markdown-writer:insert-image"
   "ctrl-i":       "markdown-writer:toggle-italic-text"

--- a/spec/markdown-writer-spec.coffee
+++ b/spec/markdown-writer-spec.coffee
@@ -17,12 +17,12 @@ describe "MarkdownWriter", ->
       activationPromise = atom.packages.activatePackage("markdown-writer")
 
   # To test dispatch commands, remove the comments in markdown-writer.coffee to
-  # make sure testMode not actually trigger events.
+  # make sure _skipAction not actually trigger events.
   #
   # TODO Update individual command specs to test command dispatches in future.
   pkg.activationCommands["atom-workspace"].forEach (cmd) ->
-    xit "registered workspace commands #{cmd}", ->
-      atom.config.set("markdown-writer.testMode", true)
+    it "registered workspace commands #{cmd}", ->
+      atom.config.set("markdown-writer._skipAction", true)
 
       atom.commands.dispatch(workspaceView, cmd)
 
@@ -30,8 +30,8 @@ describe "MarkdownWriter", ->
       runs -> expect(true).toBe(true)
 
   pkg.activationCommands["atom-text-editor"].forEach (cmd) ->
-    xit "registered editor commands #{cmd}", ->
-      atom.config.set("markdown-writer.testMode", true)
+    it "registered editor commands #{cmd}", ->
+      atom.config.set("markdown-writer._skipAction", true)
 
       atom.commands.dispatch(editorView, cmd)
 


### PR DESCRIPTION
Skip markdown-writer command if autocomplete-plus is active. #98 