### PR TITLE
Refactoring work

### DIFF
--- a/lib/commands/jump-to.coffee
+++ b/lib/commands/jump-to.coffee
@@ -51,7 +51,7 @@ class JumpTo
     key = @editor.getSelectedText() || @editor.getWordUnderCursor()
     return false unless key
 
-    key = utils.regexpEscape(REFERENCE_REGEX.exec(key)[1])
+    key = utils.escapeRegExp(REFERENCE_REGEX.exec(key)[1])
 
     found = false
     @editor.buffer.scan /// \[ #{key} \] ///g, (match) =>

--- a/lib/commands/publish-draft.coffee
+++ b/lib/commands/publish-draft.coffee
@@ -62,16 +62,18 @@ class PublishDraft
     template = config.get("newPostFileName")
 
     date = utils.getDate()
+    slug = @_getPostSlug()
     info =
-      title: @_getPostTitle()
+      title: slug
+      slug: slug
       extension: @_getPostExtension()
 
     utils.template(template, $.extend(info, date))
 
-  _getPostTitle: ->
+  _getPostSlug: ->
     useFrontMatter = !@draftPath || !!config.get("publishRenameBasedOnTitle")
-    title = utils.dasherize(@frontMatter.get("title")) if useFrontMatter
-    title || utils.getTitleSlug(@draftPath) || utils.dasherize("New Post")
+    slug = utils.slugize(@frontMatter.get("title"), config.get('slugSeparator')) if useFrontMatter
+    slug || utils.getTitleSlug(@draftPath) || utils.slugize("New Post", config.get('slugSeparator'))
 
   _getPostExtension: ->
     extname = path.extname(@draftPath) if !!config.get("publishKeepFileExtname")

--- a/lib/commands/style-line.coffee
+++ b/lib/commands/style-line.coffee
@@ -75,7 +75,7 @@ class StyleLine
     return matches[1..].join("")
 
   getStylePattern: ->
-    before = @style.regexBefore || utils.regexpEscape(@style.before)
-    after = @style.regexAfter || utils.regexpEscape(@style.after)
+    before = @style.regexBefore || utils.escapeRegExp(@style.before)
+    after = @style.regexAfter || utils.escapeRegExp(@style.after)
 
     /// ^(\s*) (?:#{before})? (.*?) (?:#{after})? (\s*)$ ///i

--- a/lib/commands/style-text.coffee
+++ b/lib/commands/style-text.coffee
@@ -68,8 +68,8 @@ class StyleText
     return text
 
   getStylePattern: ->
-    before = @style.regexBefore || utils.regexpEscape(@style.before)
-    after = @style.regexAfter || utils.regexpEscape(@style.after)
+    before = @style.regexBefore || utils.escapeRegExp(@style.before)
+    after = @style.regexAfter || utils.escapeRegExp(@style.after)
 
     ///
     ^([\s\S]*?)                    # random text at head

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -31,9 +31,9 @@ class Configuration
     urlForCategories: ""
 
     # filename format of new drafts created
-    newDraftFileName: "{title}{extension}"
+    newDraftFileName: "{slug}{extension}"
     # filename format of new posts created
-    newPostFileName: "{year}-{month}-{day}-{title}{extension}"
+    newPostFileName: "{year}-{month}-{day}-{slug}{extension}"
     # front matter template
     frontMatter: """
       ---
@@ -45,6 +45,8 @@ class Configuration
 
     # file extension of posts/drafts
     fileExtension: ".markdown"
+    # file slug separator
+    slugSeparator: "-"
     # use relative path to image from the opened file
     relativeImagePath: false
 

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -34,12 +34,14 @@ class Configuration
     newDraftFileName: "{slug}{extension}"
     # filename format of new posts created
     newPostFileName: "{year}-{month}-{day}-{slug}{extension}"
+    # front matter date format
+    frontMatterDate: "{year}-{month}-{day} {hour}:{minute}"
     # front matter template
     frontMatter: """
       ---
-      layout: <layout>
-      title: "<title>"
-      date: "<date>"
+      layout: "{layout}"
+      title: "{title}"
+      date: "{date}"
       ---
       """
 
@@ -65,7 +67,7 @@ class Configuration
     # reference tag indent space (0 or 2)
     referenceIndentLength: 2
 
-    # NOTE textStyles and lineStyles
+    # TextStyles and LineStyles
     #
     # In `regex{Before,After}`, `regexMatch{Before,After}`, DO NOT USE CAPTURE GROUP!
     # Capture group will break things! USE non-capturing group `(?:)` instead.
@@ -77,7 +79,7 @@ class Configuration
     # If this match regex test = true, the style will be replaced by new style.
     #
     # When `regexMatch{Before,After}` is not specified, `regex{Before,After}` is used instead.
-
+    #
     # text styles related
     textStyles:
       code:
@@ -122,7 +124,7 @@ class Configuration
       blockquote: before: "> "
 
     # image tag template
-    imageTag: "![<alt>](<src>)"
+    imageTag: "![{alt}]({src})"
 
     # table default alignments: "empty", "left", "right", "center"
     tableAlignment: "empty"
@@ -137,11 +139,16 @@ class Configuration
       'text.plain.null-grammar'
     ]
 
+    # template variables is a key-value map that used in template string
+    # e.g. you can have `posts/{author}/{year}` in newPostFileName after you set author.
+    templateVariables:
+      author: ''
+
   @engines:
     html:
       imageTag: """
-        <a href="<site>/<slug>.html" target="_blank">
-          <img class="align<align>" alt="<alt>" src="<src>" width="<width>" height="<height>" />
+        <a href="{site}/{slug}.html" target="_blank">
+          <img class="align{align}" alt="{alt}" src="{src}" width="{width}" height="{height}" />
         </a>
         """
     jekyll:
@@ -156,9 +163,9 @@ class Configuration
     hexo:
       newPostFileName: "{title}{extension}"
       frontMatter: """
-        layout: <layout>
-        title: "<title>"
-        date: "<date>"
+        layout: "{layout}"
+        title: "{title}"
+        date: "{date}"
         ---
         """
 

--- a/lib/helpers/front-matter.coffee
+++ b/lib/helpers/front-matter.coffee
@@ -12,8 +12,11 @@ FRONT_MATTER_REGEX = ///
 
 module.exports =
 class FrontMatter
-  constructor: (editor) ->
+  # options:
+  #   silient = true/false
+  constructor: (editor, options = {}) ->
     @editor = editor
+    @options = options
     @content = {}
     @leadingFence = true
     @isEmpty = true
@@ -27,10 +30,12 @@ class FrontMatter
         @isEmpty = false
       catch error
         @parseError = error
-        atom.confirm
-          message: "[Markdown Writer] Error!"
-          detailedMessage: "Invalid Front Matter:\n#{error.message}"
-          buttons: ['OK']
+        @content = {}
+        unless options["silent"] == true
+          atom.confirm
+            message: "[Markdown Writer] Error!"
+            detailedMessage: "Invalid Front Matter:\n#{error.message}"
+            buttons: ['OK']
 
   _findFrontMatter: (onMatch) ->
     @editor.buffer.scan(FRONT_MATTER_REGEX, onMatch)
@@ -52,6 +57,8 @@ class FrontMatter
 
   setIfExists: (field, content) ->
     @content[field] = content if @has(field)
+
+  getContent: -> JSON.parse(JSON.stringify(@content))
 
   getContentText: ->
     text = yaml.safeDump(@content)

--- a/lib/helpers/template-helper.coffee
+++ b/lib/helpers/template-helper.coffee
@@ -1,0 +1,60 @@
+{$} = require "atom-space-pen-views"
+path = require "path"
+
+config = require "../config"
+utils = require "../utils"
+FrontMatter = require "./front-matter"
+
+# All template should be created from here
+create = (key, frontMatter, dateTime, extraData) ->
+  data = $.extend({}, getTemplateVariables(), frontMatter, dateTime, extraData)
+  utils.template(config.get(key), data)
+
+getTemplateVariables = ->
+  $.extend({ site: config.get("siteUrl") }, config.get("templateVariables") || {})
+
+getDateTime = (date = new Date()) ->
+  utils.getDate(date)
+
+getFrontMatterDate = (dateTime) ->
+  utils.template(config.get("frontMatterDate"), dateTime)
+
+parseFrontMatterDate = (str) ->
+  fn = utils.untemplate(config.get("frontMatterDate"))
+  dateHash = fn(str)
+  utils.parseDate(dateHash) if dateHash
+
+getFrontMatter = (frontMatter) ->
+  layout: frontMatter.getLayout()
+  published: frontMatter.getPublished()
+  title: frontMatter.getTitle()
+  slug: frontMatter.getSlug()
+  date: frontMatter.getDate()
+  extension: frontMatter.getExtension()
+
+parseFileSlug = (filePath) ->
+  return "" unless filePath
+
+  filename = path.basename(filePath)
+  templates = [config.get("newPostFileName"), config.get("newDraftFileName"), "{slug}{extension}"]
+
+  for template in templates
+    hash = utils.untemplate(template)(filename)
+    if hash && (hash["slug"] || hash["title"])
+      return hash["slug"] || hash["title"]
+
+getEditor = (editor) ->
+  data = new FrontMatter(editor, { silent: true }).getContent()
+  data["slug"] = parseFileSlug(editor.getPath()) || utils.slugize(data['title'], config.get('slugSeparator'))
+  data["extension"] = path.extname(@draftPath) || config.get("fileExtension")
+  data
+
+module.exports =
+  create: create
+  getTemplateVariables: getTemplateVariables
+  getDateTime: getDateTime
+  getFrontMatter: getFrontMatter
+  getFrontMatterDate: getFrontMatterDate
+  parseFrontMatterDate: parseFrontMatterDate
+  getEditor: getEditor
+  parseFileSlug: parseFileSlug

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -10,7 +10,7 @@ getJSON = (uri, succeed, error) ->
   return error() if uri.length == 0
   $.getJSON(uri).done(succeed).fail(error)
 
-regexpEscape = (str) ->
+escapeRegExp = (str) ->
   return "" unless str
   str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&')
 
@@ -171,7 +171,7 @@ parseInlineLink = (input) ->
 #
 
 REFERENCE_LINK_REGEX_OF = (id, opts = {}) ->
-  id = regexpEscape(id) unless opts.noEscape
+  id = escapeRegExp(id) unless opts.noEscape
   ///
   \[(#{id})\]\ ?\[\]            # [text][]
   |                             # or
@@ -186,7 +186,7 @@ REFERENCE_LINK_REGEX_OF = (id, opts = {}) ->
 REFERENCE_LINK_REGEX = REFERENCE_LINK_REGEX_OF(".+?", noEscape: true)
 
 REFERENCE_DEF_REGEX_OF = (id, opts = {}) ->
-  id = regexpEscape(id) unless opts.noEscape
+  id = escapeRegExp(id) unless opts.noEscape
   /// ^\ *                      # start of line with any spaces
   \[(#{id})\]:\ +               # [id]: followed by spaces
   (\S*?)                        # link
@@ -424,9 +424,9 @@ getTextBufferRange = (editor, scopeSelector, selection) ->
 
 module.exports =
   getJSON: getJSON
-  regexpEscape: regexpEscape
   dasherize: dasherize
   
+  escapeRegExp: escapeRegExp
   getPackagePath: getPackagePath
   getProjectPath: getProjectPath
 

--- a/lib/views/manage-post-tags-view.coffee
+++ b/lib/views/manage-post-tags-view.coffee
@@ -21,6 +21,6 @@ class ManagePostTagsView extends ManageFrontMatterView
   # rank tags based on the number of times they appeared in content
   rankTags: (tags, content) ->
     tags.forEach (tag) ->
-      tagRegex = /// #{utils.regexpEscape(tag.name)} ///ig
+      tagRegex = /// #{utils.escapeRegExp(tag.name)} ///ig
       tag.count = content.match(tagRegex)?.length || 0
     tags.sort (t1, t2) -> t2.count - t1.count

--- a/lib/views/new-file-view.coffee
+++ b/lib/views/new-file-view.coffee
@@ -74,14 +74,15 @@ class NewFileView extends View
 
   getFileName: ->
     template = config.get(@constructor.fileNameConfig)
-
     info =
-      title: utils.dasherize(@getTitle())
+      title: @getTitleSlug()
+      slug: @getTitleSlug()
       extension: config.get("fileExtension")
-
     utils.template(template, $.extend(info, @getDate()))
 
   getTitle: -> @titleEditor.getText() || "New #{@constructor.fileType}"
+
+  getTitleSlug: -> utils.slugize(@getTitle(), config.get('slugSeparator'))
 
   getDate: -> utils.parseDateStr(@dateEditor.getText())
 
@@ -94,6 +95,6 @@ class NewFileView extends View
     layout: "post"
     published: @getPublished()
     title: @getTitle()
-    slug: utils.dasherize(@getTitle())
+    slug: @getTitleSlug()
     date: "#{@dateEditor.getText()} #{utils.getTimeStr()}"
     dateTime: @getDate()

--- a/lib/views/new-file-view.coffee
+++ b/lib/views/new-file-view.coffee
@@ -4,6 +4,7 @@ fs = require "fs-plus"
 
 config = require "../config"
 utils = require "../utils"
+templateHelper = require "../helpers/template-helper"
 
 module.exports =
 class NewFileView extends View
@@ -27,19 +28,24 @@ class NewFileView extends View
   initialize: ->
     utils.setTabIndex([@titleEditor, @pathEditor, @dateEditor])
 
-    @pathEditor.getModel().onDidChange => @updatePath()
-    @dateEditor.getModel().onDidChange => @updatePath()
     @titleEditor.getModel().onDidChange => @updatePath()
+    @pathEditor.getModel().onDidChange => @updatePath()
+    # update pathEditor to reflect date changes, however this will overwrite user changes
+    @dateEditor.getModel().onDidChange =>
+      @pathEditor.setText(templateHelper.create(@constructor.pathConfig, @getDateTime()))
 
     atom.commands.add @element,
-      "core:confirm": => @createPost()
+      "core:confirm": => @createFile()
       "core:cancel": => @detach()
+
+    # save current date time as base
+    @dateTime = templateHelper.getDateTime()
 
   display: ->
     @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
     @previouslyFocusedElement = $(document.activeElement)
-    @dateEditor.setText(utils.getDateStr())
-    @pathEditor.setText(utils.dirTemplate(config.get(@constructor.pathConfig)))
+    @dateEditor.setText(templateHelper.getFrontMatterDate(@dateTime))
+    @pathEditor.setText(templateHelper.create(@constructor.pathConfig, @dateTime))
     @panel.show()
     @titleEditor.focus()
 
@@ -49,52 +55,38 @@ class NewFileView extends View
       @previouslyFocusedElement?.focus()
     super
 
-  createPost: ->
+  createFile: ->
     try
-      post = @getFullPath()
+      filePath = path.join(@getFileDir(), @getFilePath())
 
-      if fs.existsSync(post)
-        @error.text("File #{@getFullPath()} already exists!")
+      if fs.existsSync(filePath)
+        @error.text("File #{filePath} already exists!")
       else
-        fs.writeFileSync(post, @generateFrontMatter(@getFrontMatter()))
-        atom.workspace.open(post)
+        frontMatterText = templateHelper.create("frontMatter", @getFrontMatter(), @getDateTime())
+        fs.writeFileSync(filePath, frontMatterText)
+        atom.workspace.open(filePath)
         @detach()
     catch error
       @error.text("#{error.message}")
 
   updatePath: ->
     @message.html """
-    <b>Site Directory:</b> #{config.get("siteLocalDir") || utils.getProjectPath()}/<br/>
-    <b>Create #{@constructor.fileType} At:</b> #{@getPostPath()}
+    <b>Site Directory:</b> #{@getFileDir()}/<br/>
+    <b>Create #{@constructor.fileType} At:</b> #{@getFilePath()}
     """
 
-  getFullPath: -> path.join(config.get("siteLocalDir") || utils.getProjectPath(), @getPostPath())
-
-  getPostPath: -> path.join(@pathEditor.getText(), @getFileName())
-
-  getFileName: ->
-    template = config.get(@constructor.fileNameConfig)
-    info =
-      title: @getTitleSlug()
-      slug: @getTitleSlug()
-      extension: config.get("fileExtension")
-    utils.template(template, $.extend(info, @getDate()))
-
+  # common interface for FrontMatter
+  getLayout: -> "post"
+  getPublished: -> @constructor.fileType == "Post"
   getTitle: -> @titleEditor.getText() || "New #{@constructor.fileType}"
+  getSlug: -> utils.slugize(@getTitle(), config.get('slugSeparator'))
+  getDate: -> templateHelper.getFrontMatterDate(@getDateTime())
+  getExtension: -> config.get("fileExtension")
 
-  getTitleSlug: -> utils.slugize(@getTitle(), config.get('slugSeparator'))
+  # new file and front matters
+  getFileDir: -> config.get("siteLocalDir") || utils.getProjectPath()
+  getFilePath: -> path.join(@pathEditor.getText(), @getFileName())
 
-  getDate: -> utils.parseDateStr(@dateEditor.getText())
-
-  getPublished: -> @constructor.fileType == 'Post'
-
-  generateFrontMatter: (data) ->
-    utils.template(config.get("frontMatter"), data)
-
-  getFrontMatter: ->
-    layout: "post"
-    published: @getPublished()
-    title: @getTitle()
-    slug: @getTitleSlug()
-    date: "#{@dateEditor.getText()} #{utils.getTimeStr()}"
-    dateTime: @getDate()
+  getFileName: -> templateHelper.create(@constructor.fileNameConfig, @getFrontMatter(), @getDateTime())
+  getDateTime: -> templateHelper.parseFrontMatterDate(@dateEditor.getText()) || @dateTime
+  getFrontMatter: -> templateHelper.getFrontMatter(this)

--- a/spec/commands/publish-draft-spec.coffee
+++ b/spec/commands/publish-draft-spec.coffee
@@ -17,7 +17,7 @@ describe "PublishDraft", ->
       expect(publishDraft.draftPath).toMatch("fixtures/empty.markdown")
       expect(publishDraft.postPath).toMatch(/\/\d{4}\/\d{4}-\d\d-\d\d-empty\.markdown/)
 
-  describe "._getPostSlug", ->
+  describe ".getSlug", ->
     it "get title from front matter by config", ->
       atom.config.set("markdown-writer.publishRenameBasedOnTitle", true)
       editor.setText """
@@ -27,7 +27,7 @@ describe "PublishDraft", ->
       """
 
       publishDraft = new PublishDraft({})
-      expect(publishDraft._getPostSlug()).toBe("markdown-writer")
+      expect(publishDraft.getSlug()).toBe("markdown-writer")
 
     it "get title from front matter if no draft path", ->
       editor.setText """
@@ -37,25 +37,27 @@ describe "PublishDraft", ->
       """
 
       publishDraft = new PublishDraft({})
-      expect(publishDraft._getPostSlug()).toBe("markdown-writer-new-post")
+      publishDraft.draftPath = undefined
+      expect(publishDraft.getSlug()).toBe("markdown-writer-new-post")
 
     it "get title from draft path", ->
       publishDraft = new PublishDraft({})
       publishDraft.draftPath = "test/name-of-post.md"
-      expect(publishDraft._getPostSlug()).toBe("name-of-post")
+      expect(publishDraft.getSlug()).toBe("name-of-post")
 
     it "get new-post when no front matter/draft path", ->
       publishDraft = new PublishDraft({})
-      expect(publishDraft._getPostSlug()).toBe("new-post")
+      publishDraft.draftPath = undefined
+      expect(publishDraft.getSlug()).toBe("new-post")
 
-  describe "._getPostExtension", ->
+  describe ".getExtension", ->
     beforeEach -> publishDraft = new PublishDraft({})
 
     it "get draft path extname by config", ->
       atom.config.set("markdown-writer.publishKeepFileExtname", true)
       publishDraft.draftPath = "test/name.md"
-      expect(publishDraft._getPostExtension()).toBe(".md")
+      expect(publishDraft.getExtension()).toBe(".md")
 
     it "get default extname", ->
       publishDraft.draftPath = "test/name.md"
-      expect(publishDraft._getPostExtension()).toBe(".markdown")
+      expect(publishDraft.getExtension()).toBe(".markdown")

--- a/spec/commands/publish-draft-spec.coffee
+++ b/spec/commands/publish-draft-spec.coffee
@@ -17,7 +17,7 @@ describe "PublishDraft", ->
       expect(publishDraft.draftPath).toMatch("fixtures/empty.markdown")
       expect(publishDraft.postPath).toMatch(/\/\d{4}\/\d{4}-\d\d-\d\d-empty\.markdown/)
 
-  describe ".getPostTile", ->
+  describe "._getPostSlug", ->
     it "get title from front matter by config", ->
       atom.config.set("markdown-writer.publishRenameBasedOnTitle", true)
       editor.setText """
@@ -27,7 +27,7 @@ describe "PublishDraft", ->
       """
 
       publishDraft = new PublishDraft({})
-      expect(publishDraft._getPostTitle()).toBe("markdown-writer")
+      expect(publishDraft._getPostSlug()).toBe("markdown-writer")
 
     it "get title from front matter if no draft path", ->
       editor.setText """
@@ -37,18 +37,18 @@ describe "PublishDraft", ->
       """
 
       publishDraft = new PublishDraft({})
-      expect(publishDraft._getPostTitle()).toBe("markdown-writer-new-post")
+      expect(publishDraft._getPostSlug()).toBe("markdown-writer-new-post")
 
     it "get title from draft path", ->
       publishDraft = new PublishDraft({})
       publishDraft.draftPath = "test/name-of-post.md"
-      expect(publishDraft._getPostTitle()).toBe("name-of-post")
+      expect(publishDraft._getPostSlug()).toBe("name-of-post")
 
     it "get new-post when no front matter/draft path", ->
       publishDraft = new PublishDraft({})
-      expect(publishDraft._getPostTitle()).toBe("new-post")
+      expect(publishDraft._getPostSlug()).toBe("new-post")
 
-  describe ".getPostExtension", ->
+  describe "._getPostExtension", ->
     beforeEach -> publishDraft = new PublishDraft({})
 
     it "get draft path extname by config", ->

--- a/spec/helpers/template-helper-spec.coffee
+++ b/spec/helpers/template-helper-spec.coffee
@@ -1,0 +1,35 @@
+helper = require "../../lib/helpers/template-helper"
+
+describe "templateHelper", ->
+  beforeEach ->
+    waitsForPromise -> atom.workspace.open("front-matter.markdown")
+
+  describe ".getFrontMatterDate", ->
+    it "get date + time to string", ->
+      date = helper.getFrontMatterDate(helper.getDateTime())
+      expect(date).toMatch(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}/)
+
+  describe ".parseFrontMatterDate", ->
+    it "parse date + time to hash", ->
+      atom.config.set("markdown-writer.frontMatterDate", "{year}-{month}-{day} {hour}:{minute}")
+      dateTime = helper.parseFrontMatterDate("2016-01-03 19:11")
+      expected = year: "2016", month: "01", day: "03", hour: "19", minute: "11"
+      expect(dateTime[key]).toEqual(value) for key, value in expected
+
+  describe ".parseFileSlug", ->
+    it "get title slug", ->
+      slug = "hello-world"
+      fixture = "abc/hello-world.markdown"
+      expect(helper.parseFileSlug(fixture)).toEqual(slug)
+      fixture = "abc/2014-02-12-hello-world.markdown"
+      expect(helper.parseFileSlug(fixture)).toEqual(slug)
+
+    it "get title slug", ->
+      atom.config.set("markdown-writer.newPostFileName", "{slug}-{day}-{month}-{year}{extension}")
+      slug = "hello-world"
+      fixture = "abc/hello-world-02-12-2014.markdown"
+      expect(helper.parseFileSlug(fixture)).toEqual(slug)
+
+    it "get empty slug", ->
+      expect(helper.parseFileSlug(undefined)).toEqual("")
+      expect(helper.parseFileSlug("")).toEqual("")

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -7,18 +7,26 @@ describe "utils", ->
 # General Utils
 #
 
-  describe ".dasherize", ->
-    it "dasherize string", ->
+  describe ".slugize", ->
+    it "slugize string", ->
       fixture = "hello world!"
-      expect(utils.dasherize(fixture)).toEqual("hello-world")
+      expect(utils.slugize(fixture)).toEqual("hello-world")
       fixture = "hello-world"
-      expect(utils.dasherize(fixture)).toEqual("hello-world")
+      expect(utils.slugize(fixture)).toEqual("hello-world")
       fixture = " hello     World"
-      expect(utils.dasherize(fixture)).toEqual("hello-world")
+      expect(utils.slugize(fixture)).toEqual("hello-world")
 
-    it "dasherize empty string", ->
-      expect(utils.dasherize(undefined)).toEqual("")
-      expect(utils.dasherize("")).toEqual("")
+    it "slugize chinese", ->
+      fixture = "中文也可以"
+      expect(utils.slugize(fixture)).toEqual("中文也可以")
+      fixture = "中文：也可以"
+      expect(utils.slugize(fixture)).toEqual("中文：也可以")
+      fixture = " 「中文」  『也可以』"
+      expect(utils.slugize(fixture)).toEqual("「中文」-『也可以』")
+
+    it "slugize empty string", ->
+      expect(utils.slugize(undefined)).toEqual("")
+      expect(utils.slugize("")).toEqual("")
 
   describe ".getPackagePath", ->
     it "get the package path", ->
@@ -122,7 +130,7 @@ describe "utils", ->
     fixture = "![text](url)"
     expect(utils.parseImage(fixture)).toEqual
       alt: "text", src: "url", title: ""
-      
+
   it "check is valid image file", ->
     fixture = "fixtures/abc.jpg"
     expect(utils.isImageFile(fixture)).toBe(true)

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -42,15 +42,6 @@ describe "utils", ->
 # Template
 #
 
-  describe ".dirTemplate", ->
-    it "generate posts directory without token", ->
-      expect(utils.dirTemplate("_posts/")).toEqual("_posts/")
-
-    it "generate posts directory with tokens", ->
-      date = utils.getDate()
-      result = utils.dirTemplate("_posts/{year}/{month}")
-      expect(result).toEqual("_posts/#{date.year}/#{date.month}")
-
   describe ".template", ->
     it "generate template", ->
       fixture = "<a href=''>hello <title>! <from></a>"
@@ -62,33 +53,33 @@ describe "utils", ->
       expect(utils.template(fixture, url: "//", title: ''))
         .toEqual("<a href='//' title=''><img></a>")
 
+  describe ".untemplate", ->
+    it "generate untemplate for normal text", ->
+      fn = utils.untemplate("text")
+      expect(fn("text")).toEqual(_: "text")
+      expect(fn("abc")).toEqual(undefined)
+
+    it "generate untemplate for template", ->
+      fn = utils.untemplate("{year}-{month}")
+      expect(fn("2016-11-12")).toEqual(undefined)
+      expect(fn("2016-01")).toEqual(_: "2016-01", year: "2016", month: "01")
+
+    it "generate untemplate for complex template", ->
+      fn = utils.untemplate("{year}-{month}-{day} {hour}:{minute}")
+      expect(fn("2016-11-12")).toEqual(undefined)
+      expect(fn("2016-01-03 12:19")).toEqual(
+        _: "2016-01-03 12:19", year: "2016", month: "01",
+        day: "03", hour: "12", minute: "19")
+
 # ==================================================
 # Date and Time
 #
 
-  it "get date dashed string", ->
-    date = utils.getDate()
-    expect(utils.getDateStr()).toEqual("#{date.year}-#{date.month}-#{date.day}")
-    expect(utils.getTimeStr()).toEqual("#{date.hour}:#{date.minute}")
-
-# ==================================================
-# Title and Slug
-#
-
-  describe ".getTitleSlug", ->
-    it "get title slug", ->
-      slug = "hello-world"
-
-      fixture = "abc/hello-world.markdown"
-      expect(utils.getTitleSlug(slug)).toEqual(slug)
-      fixture = "abc/2014-02-12-hello-world.markdown"
-      expect(utils.getTitleSlug(fixture)).toEqual(slug)
-      fixture = "abc/02-12-2014-hello-world.markdown"
-      expect(utils.getTitleSlug(fixture)).toEqual(slug)
-
-    it "get empty slug", ->
-      expect(utils.getTitleSlug(undefined)).toEqual("")
-      expect(utils.getTitleSlug("")).toEqual("")
+  describe ".parseDate", ->
+    it "parse date dashed string", ->
+      date = utils.getDate()
+      parseDate = utils.parseDate(date)
+      expect(parseDate).toEqual(date)
 
 # ==================================================
 # Image HTML Tag

--- a/spec/views/insert-image-view-spec.coffee
+++ b/spec/views/insert-image-view-spec.coffee
@@ -4,22 +4,22 @@ config = require "../../lib/config"
 
 describe "InsertImageView", ->
   [editor, insertImageView] = []
-  
+
   beforeEach ->
     waitsForPromise -> atom.workspace.open("empty.markdown")
-    
+
     runs ->
-      insertImageView = new InsertImageView({})
       editor = atom.workspace.getActiveTextEditor()
+      insertImageView = new InsertImageView({})
 
   describe ".isInSiteDir", ->
     beforeEach ->
       atom.config.set("markdown-writer.siteLocalDir", editor.getPath().replace("empty.markdown", ""))
-      
+
     it "check a file is in site local dir", ->
       fixture = "#{config.get("siteLocalDir")}/image.jpg"
       expect(insertImageView.isInSiteDir(fixture)).toBe(true)
-      
+
     it "check a file is not in site local dir", ->
       fixture = 'some/random/path/image.jpg'
       expect(insertImageView.isInSiteDir(fixture)).toBe(false)
@@ -28,7 +28,7 @@ describe "InsertImageView", ->
     it "return empty image path", ->
       fixture = ""
       expect(insertImageView.resolveImagePath(fixture)).toBe(fixture)
-    
+
     it "return URL image path", ->
       fixture = "https://assets-cdn.github.com/images/icons/emoji/octocat.png"
       expect(insertImageView.resolveImagePath(fixture)).toBe(fixture)
@@ -37,37 +37,38 @@ describe "InsertImageView", ->
       insertImageView.editor = editor
       fixture = editor.getPath().replace("empty.markdown", "octocat.png")
       expect(insertImageView.resolveImagePath(fixture)).toBe(fixture)
-      
+
     it "return absolute image path", ->
       insertImageView.editor = editor
       atom.config.set("markdown-writer.siteLocalDir", editor.getPath().replace("empty.markdown", ""))
-      
+
       fixture = "octocat.png"
       expected = editor.getPath().replace("empty.markdown", "octocat.png")
       expect(insertImageView.resolveImagePath(fixture)).toBe(expected)
-      
+
   describe ".generateImageSrc", ->
     it "return empty image path", ->
       fixture = ""
       expect(insertImageView.generateImageSrc(fixture)).toBe(fixture)
-    
+
     it "return URL image path", ->
       fixture = "https://assets-cdn.github.com/images/icons/emoji/octocat.png"
       expect(insertImageView.generateImageSrc(fixture)).toBe(fixture)
-    
+
     it "return relative image path from file", ->
       insertImageView.editor = editor
       atom.config.set("markdown-writer.relativeImagePath", true)
-      
+
       fixture = editor.getPath().replace("empty.markdown", "octocat.png")
       expect(insertImageView.generateImageSrc(fixture)).toBe("octocat.png")
-      
+
     it "return relative image path from site", ->
       atom.config.set("markdown-writer.siteLocalDir", "/assets/images/icons/emoji")
-      
+
       fixture = "/assets/images/icons/emoji/octocat.png"
       expect(insertImageView.generateImageSrc(fixture)).toBe("octocat.png")
 
     it "return image dir path", ->
+      insertImageView.display()
       fixture = "octocat.png"
       expect(insertImageView.generateImageSrc(fixture)).toMatch(/\d{4}\/\d{2}\/octocat\.png/)

--- a/spec/views/new-file-view-spec.coffee
+++ b/spec/views/new-file-view-spec.coffee
@@ -14,36 +14,11 @@ describe "NewFileView", ->
 
     describe '.getFileName', ->
       it "get filename in hexo format", ->
-        atom.config.set("markdown-writer.newFileFileName", "file-{title}{extension}")
+        atom.config.set("markdown-writer.newFileFileName", "file-{slug}{extension}")
         atom.config.set("markdown-writer.fileExtension", ".md")
 
         newFileView.titleEditor.setText("Hexo format")
-        newFileView.dateEditor.setText("2014-11-19")
-
         expect(newFileView.getFileName()).toBe("file-hexo-format.md")
-
-    describe '.generateFrontMatter', ->
-      it "generate correctly", ->
-        frontMatter =
-          layout: "test", title: "the actual title", date: "2014-11-19"
-
-        expect(newFileView.generateFrontMatter(frontMatter)).toBe """
-        ---
-        layout: test
-        title: "the actual title"
-        date: "2014-11-19"
-        ---
-        """
-
-      it "generate based on setting", ->
-        frontMatter =
-          layout: "test", title: "the actual title", date: "2014-11-19"
-
-        atom.config.set("markdown-writer.frontMatter", "title: <title>")
-
-        expect(newFileView.generateFrontMatter(frontMatter)).toBe(
-          "title: the actual title")
-
 
   describe "NewDraftView", ->
     newDraftView = null
@@ -61,18 +36,17 @@ describe "NewFileView", ->
       it 'display correct message', ->
         newDraftView.display()
 
-        newDraftView.dateEditor.setText("2015-08-23")
+        newDraftView.dateEditor.setText("2015-08-23 11:19")
         newDraftView.titleEditor.setText("Draft Title")
-        path = atom.project.getPaths()[0]
 
         expect(newDraftView.message.text()).toBe """
-        Site Directory: #{path}/
+        Site Directory: #{atom.project.getPaths()[0]}/
         Create Draft At: _drafts/draft-title.markdown
         """
 
     describe ".getFrontMatter", ->
       it "get the correct front matter", ->
-        newDraftView.dateEditor.setText("2015-08-23")
+        newDraftView.dateEditor.setText("2015-08-23 11:19")
         newDraftView.titleEditor.setText("Draft Title")
 
         frontMatter = newDraftView.getFrontMatter()
@@ -80,6 +54,7 @@ describe "NewFileView", ->
         expect(frontMatter.published).toBe(false)
         expect(frontMatter.title).toBe("Draft Title")
         expect(frontMatter.slug).toBe("draft-title")
+        expect(frontMatter.date).toBe("2015-08-23 11:19")
 
   describe "NewPostView", ->
     newPostView = null
@@ -97,18 +72,17 @@ describe "NewFileView", ->
       it 'display correct message', ->
         newPostView.display()
 
-        newPostView.dateEditor.setText("2015-08-23")
+        newPostView.dateEditor.setText("2015-08-23 11:19")
         newPostView.titleEditor.setText("Post's Title")
-        path = atom.project.getPaths()[0]
 
         expect(newPostView.message.text()).toBe """
-        Site Directory: #{path}/
+        Site Directory: #{atom.project.getPaths()[0]}/
         Create Post At: _posts/2015/2015-08-23-post-s-title.markdown
         """
 
     describe ".getFrontMatter", ->
       it "get the correct front matter", ->
-        newPostView.dateEditor.setText("2015-08-24")
+        newPostView.dateEditor.setText("2015-08-24 11:19")
         newPostView.titleEditor.setText("Post's Title: Subtitle")
 
         frontMatter = newPostView.getFrontMatter()
@@ -116,3 +90,4 @@ describe "NewFileView", ->
         expect(frontMatter.published).toBe(true)
         expect(frontMatter.title).toBe("Post's Title: Subtitle")
         expect(frontMatter.slug).toBe("post-s-title-subtitle")
+        expect(frontMatter.date).toBe("2015-08-24 11:19")

--- a/spec/views/new-file-view-spec.coffee
+++ b/spec/views/new-file-view-spec.coffee
@@ -103,7 +103,7 @@ describe "NewFileView", ->
 
         expect(newPostView.message.text()).toBe """
         Site Directory: #{path}/
-        Create Post At: _posts/2015/2015-08-23-posts-title.markdown
+        Create Post At: _posts/2015/2015-08-23-post-s-title.markdown
         """
 
     describe ".getFrontMatter", ->
@@ -115,4 +115,4 @@ describe "NewFileView", ->
         expect(frontMatter.layout).toBe("post")
         expect(frontMatter.published).toBe(true)
         expect(frontMatter.title).toBe("Post's Title: Subtitle")
-        expect(frontMatter.slug).toBe("posts-title-subtitle")
+        expect(frontMatter.slug).toBe("post-s-title-subtitle")


### PR DESCRIPTION
- Rename `regexpEscape` to `escapeRegExp`
- Improve `utils.dasherize` to `utils.slugize`
  - Change all `{title}` to `{slug}`
  - Added config `slugSeparator`
- Change all `<template>` to `{template}`
- Extract `template-helper`
  - Added `utils.untemplate` to reverse a generated string based on template
  - Use `templateHelper.create` for any template creation
  - Added config `templateVariables` for custom variables
  - Added config `frontMatterDate` for front matter date format