### PR TITLE
Add support for language-markdown package

### DIFF
--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -134,6 +134,7 @@ class Configuration
     # filetypes markdown-writer commands apply
     grammars: [
       'source.gfm'
+      'text.md'
       'source.litcoffee'
       'text.plain'
       'text.plain.null-grammar'


### PR DESCRIPTION
The [language-markdown](https://github.com/burodepeper/language-markdown) package promises to add support for more than just GFM. This includes the new CommonMark syntax, as well as front-matters, and a bunch of other goodies. As such, this package should apply to it, too.