### PR TITLE
Add Filetype configs and Asciidoc filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Apm Version](https://img.shields.io/apm/v/markdown-writer.svg)](https://atom.io/packages/markdown-writer)
 [![Apm Downloads](https://img.shields.io/apm/dm/markdown-writer.svg)](https://atom.io/packages/markdown-writer)
 
-Adds tons of features to make [Atom](https://atom.io/) an even better Markdown editor!
+Adds tons of features to make [Atom](https://atom.io/) an even better Markdown/AsciiDoc editor!
 
 Works great with static blogging as well. Try it with [Jekyll](http://jekyllrb.com/), [Octopress](http://octopress.org/), [Hexo](http://hexo.io/) and any of your favorite static blog engines.
 
@@ -65,9 +65,11 @@ More GIFs Here: [Create New Post](http://i.imgur.com/BwntxhB.gif), [Insert Refer
   - Jump to reference marker/definition (`cmd-j cmd-d`)
 - **Markdown cheat sheet** (`markdown-writer:open-cheat-sheet`).
 - **Correct order list numbers** (`markdown-writer:correct-order-list-numbers`).
-- **Toolbar for markdown writer** found at [tool-bar-markdown-writer][82a2aced].
+- **Toolbar for Markdown Writer** is available at [tool-bar-markdown-writer][82a2aced].
+- **AsciiDoc support** with [language-asciidoc][2f0cb1f9].
 
   [82a2aced]: https://atom.io/packages/tool-bar-markdown-writer "Toobar for Markdown Writer"
+  [2f0cb1f9]: https://atom.io/packages/language-asciidoc "AsciiDoc Language Package for Atom"
 
 You can find and trigger all features in:
 

--- a/lib/config.cson
+++ b/lib/config.cson
@@ -9,19 +9,21 @@
 # NOTE 2: Strings need to be quoted.
 #
 
-# root directory of your blog (leave empty to source the current project path)
-siteLocalDir: ""
-
+# static engine of your blog
+# e.g. one of: general, html, jekyll, octopress, hexo
+siteEngine: "general"
 # website URL of your blog
 siteUrl: ""
-# static engine of your blog
-# one of these: general, html, jekyll, octopress, hexo
-siteEngine: "general"
+
+# root directory of your blog
+# e.g. leave empty to source the current project path (recommended)
+siteLocalDir: ""
 # directory to drafts from siteLocalDir
 siteDraftsDir: "_drafts/"
 # directory to posts from siteLocalDir
 sitePostsDir: "_posts/{year}/"
 # directory to images from siteLocalDir
+# e.g. to use the current filename directory, can use {directory}
 siteImagesDir: "images/{year}/{month}/"
 
 # URLs to tags/posts/categories JSON files

--- a/lib/config.cson
+++ b/lib/config.cson
@@ -6,13 +6,17 @@
 #
 # NOTE 1: After edit, please run command `Window: Reload` or
 #         Use menu: View -> Developer -> Reload Window.
-#
 # NOTE 2: Strings need to be quoted.
+#
 
-# website of your blog
-siteUrl: ""
-# root directory of your blog
+# root directory of your blog (leave empty to source the current project path)
 siteLocalDir: ""
+
+# website URL of your blog
+siteUrl: ""
+# static engine of your blog
+# one of these: general, html, jekyll, octopress, hexo
+siteEngine: "general"
 # directory to drafts from siteLocalDir
 siteDraftsDir: "_drafts/"
 # directory to posts from siteLocalDir
@@ -66,18 +70,19 @@ inlineNewLineContinuation: false
 
 # TextStyles and LineStyles
 #
-# In `regex{Before,After}`, `regexMatch{Before,After}`, DO NOT USE CAPTURE GROUP!
-# Capture group will break things! USE non-capturing group `(?:)` instead.
+# - Use `before` and `after` to insert text around the selected text.
+# - Use `regexMatch{Before,After}` when an exact match of the style is needed.
+#   If this regex matched true, the style will be toggled.
+# - Use `regex{Before,After}` when a general match of the style is wanted.
+#   If this regex matched true, the style will be replaced by new style.
 #
-# Use `regexMatch{Before,After}` when an exact match of the style is needed.
-# If this regex matched true, the style will be toggled.
+# NOTE
 #
-# Use `regex{Before,After}` when a general match of the style is wanted.
-# If this regex matched true, the style will be replaced by new style.
-#
-# When `regexMatch{Before,After}` is not specified, `regex{Before,After}` is used instead.
-#
-# Use `before` and `after` to insert text around the selected text.
+# - In `regex{Before,After}`, `regexMatch{Before,After}`, DO NOT USE CAPTURE GROUP!
+#   Capture group will break things! USE non-capturing group `(?:)` instead.
+# - When `regexMatch{Before,After}` is not specified, `regex{Before,After}` is used instead.
+# - In nested settings, e.g. codeblock, ul, ol, all the within nested keys need to exists if
+#   you changed one setting.
 #
 textStyles:
   code:
@@ -103,19 +108,19 @@ lineStyles:
   h4: before: "#### "
   h5: before: "##### "
   ul:
-    before: "- ",
-    regexMatchBefore: "(?:-|\\*|\\+)\\s"
-    regexBefore: "(?:-|\\*|\\+|\\d+\\.|[a-zA-Z]+\\.)\\s"
+    before: "- "
+    regexMatchBefore: "(?:-|\\*|\\+|\\.)\\s"
+    regexBefore: "(?:-|\\*|\\+|\\.|\\d+\\.|[a-zA-Z]+\\.)\\s"
   ol:
-    before: "1. ",
+    before: "1. "
     regexMatchBefore: "(?:\\d+\\.|[a-zA-Z]+\\.)\\s"
-    regexBefore: "(?:-|\\*|\\+|\\d+\\.|[a-zA-Z]+\\.)\\s"
+    regexBefore: "(?:-|\\*|\\+|\\.|\\d+\\.|[a-zA-Z]+\\.)\\s"
   task:
-    before: "- [ ] ",
+    before: "- [ ] "
     regexMatchBefore: "(?:-|\\*|\\+|\\d+\\.)\\s+\\[ ]\\s"
     regexBefore: "(?:-|\\*|\\+|\\d+\\.|[a-zA-Z]+\\.)\\s*(?:\\[[xX ]])?\\s"
   taskdone:
-    before: "- [X] ",
+    before: "- [X] "
     regexMatchBefore: "(?:-|\\*|\\+|\\d+\\.)\\s+\\[[xX]]\\s"
     regexBefore: "(?:-|\\*|\\+|\\d+\\.|[a-zA-Z]+\\.)\\s*(?:\\[[xX ]])?\\s"
   blockquote: before: "> "
@@ -143,4 +148,4 @@ tableExtraPipes: false
 # template variables is a key-value map used in template string
 # e.g. you can have `posts/{author}/{year}` in newPostFileName after you set author.
 templateVariables:
-  author: "your name"
+  author: "Your Name"

--- a/lib/filetypes/asciidoc.cson
+++ b/lib/filetypes/asciidoc.cson
@@ -1,0 +1,46 @@
+# Configurations for AsciiDoc filetype
+# Based on: http://asciidoctor.org/docs/asciidoc-writers-guide/
+
+# front matter date format, determines the {date} in frontMatter
+frontMatterDate: "{year}-{month}-{day} {hour}:{minute}"
+# front matter template, set author and email in templateVariables
+frontMatter: """
+= {title}
+{author} <{email}>
+v1.0, {date}
+:toc:
+"""
+
+# file extension of posts/drafts
+fileExtension: ".adoc"
+# file slug separator
+slugSeparator: "-"
+
+# TextStyles and LineStyles
+textStyles:
+  bold:
+    before: "*", after: "*"
+
+lineStyles:
+  h1: before: "= "
+  h2: before: "== "
+  h3: before: "=== "
+  h4: before: "==== "
+  h5: before: "===== "
+  ul:
+    before: "* "
+    regexMatchBefore: "(?:-|\\*|\\+|\\.)\\s"
+    regexBefore: "(?:-|\\*|\\+|\\.|\\d+\\.|[a-zA-Z]+\\.)\\s"
+  ol:
+    before: "1. "
+    regexMatchBefore: "(?:\\d+\\.|[a-zA-Z]+\\.)\\s"
+    regexBefore: "(?:-|\\*|\\+|\\.|\\d+\\.|[a-zA-Z]+\\.)\\s"
+
+# image tag template
+imageTag: "image::{src}[{alt}]"
+
+# inline link tag template
+linkInlineTag: "{url}[{text}]"
+# reference link tag template (fallback to inline style, ignore title)
+referenceInlineTag: "{url}[{text}]"
+referenceDefinitionTag: ""

--- a/lib/helpers/line-meta.coffee
+++ b/lib/helpers/line-meta.coffee
@@ -1,7 +1,7 @@
 utils = require "../utils"
 
-LIST_UL_TASK_REGEX = /// ^ (\s*) ([*+-]) \s+ \[[xX\ ]\] \s* (.*) $ ///
-LIST_UL_REGEX      = /// ^ (\s*) ([*+-]) \s+ (.*) $ ///
+LIST_UL_TASK_REGEX = /// ^ (\s*) ([*+-\.]) \s+ \[[xX\ ]\] \s* (.*) $ ///
+LIST_UL_REGEX      = /// ^ (\s*) ([*+-\.]) \s+ (.*) $ ///
 LIST_OL_TASK_REGEX = /// ^ (\s*) (\d+)\. \s+ \[[xX\ ]\] \s* (.*) $ ///
 LIST_OL_REGEX      = /// ^ (\s*) (\d+)\. \s+ (.*) $ ///
 LIST_AL_TASK_REGEX = /// ^ (\s*) ([a-zA-Z]+)\. \s+ \[[xX\ ]\] \s* (.*) $ ///

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "Make Atom a better Markdown editor and an easier static blogging tool.",
   "keywords": [
     "Markdown",
+    "AsciiDoc",
     "Jekyll",
     "Octopress",
     "Hexo",

--- a/spec/config-spec.coffee
+++ b/spec/config-spec.coffee
@@ -47,6 +47,23 @@ describe "config", ->
       expect(config.get("codeblock.before"))
         .toEqual(config.getDefault("codeblock.before"))
 
+  describe ".getFiletype", ->
+    originalgetActiveTextEditor = atom.workspace.getActiveTextEditor
+    afterEach -> atom.workspace.getActiveTextEditor = originalgetActiveTextEditor
+
+    it "get value from filestyle config", ->
+      atom.workspace.getActiveTextEditor = ->
+        getGrammar: -> { scopeName: "source.asciidoc" }
+
+      expect(config.getFiletype("linkInlineTag")).not.toBeNull()
+      expect(config.getFiletype("siteEngine")).not.toBeDefined()
+
+    it "get value from invalid filestyle config", ->
+      atom.workspace.getActiveTextEditor = ->
+        getGrammar: -> { scopeName: null }
+
+      expect(config.getEngine("siteEngine")).not.toBeDefined()
+
   describe ".getEngine", ->
     it "get value from engine config", ->
       config.set("siteEngine", "jekyll")


### PR DESCRIPTION
Add support of filetype specific configs.

This enables us to support other non-Markdown filetypes, but need similar writing/editing functionalities. E.g. Asciidoc/Mediawiki etc.

To support a new filetype:

- Add a config file, similar to `lib/filetypes/asciidoc.cson`
- Load this config file content in `lib/config.coffee`, e.g. `'source.asciidoc': CSON.readFileSync(configFile("filetypes", "asciidoc.cson"))`

There are many other areas to make the package more generic, e.g. regex in utils were designed to support Markdown only.