### PR TITLE
Add Disposable to views

### DIFF
--- a/coffeelint.json
+++ b/coffeelint.json
@@ -2,6 +2,9 @@
   "max_line_length": {
     "level": "ignore"
   },
+  "colon_assignment_spacing": {
+    "level": "ignore"
+  },
   "no_empty_param_list": {
     "level": "error"
   },

--- a/lib/views/insert-image-view.coffee
+++ b/lib/views/insert-image-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {$, View, TextEditorView} = require "atom-space-pen-views"
 path = require "path"
 fs = require "fs-plus"
@@ -47,9 +48,12 @@ class InsertImageView extends View
     @imageEditor.on "blur", => @updateImageSource(@imageEditor.getText().trim())
     @openImageButton.on "click", => @openImageDialog()
 
-    atom.commands.add @element,
-      "core:confirm": => @onConfirm()
-      "core:cancel":  => @detach()
+    @disposables = new CompositeDisposable()
+    @disposables.add(atom.commands.add(
+      @element, {
+        "core:confirm": => @onConfirm(),
+        "core:cancel":  => @detach()
+      }))
 
   onConfirm: ->
     imgSource = @imageEditor.getText().trim()
@@ -72,10 +76,14 @@ class InsertImageView extends View
     @imageEditor.focus()
 
   detach: ->
-    return unless @panel.isVisible()
-    @panel.hide()
-    @previouslyFocusedElement?.focus()
+    if @panel.isVisible()
+      @panel.hide()
+      @previouslyFocusedElement?.focus()
     super
+
+  detached: ->
+    @disposables?.dispose()
+    @disposables = null
 
   setFieldsFromSelection: ->
     @range = utils.getTextBufferRange(@editor, "link")

--- a/lib/views/insert-link-view.coffee
+++ b/lib/views/insert-link-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {$, View, TextEditorView} = require "atom-space-pen-views"
 CSON = require "season"
 fs = require "fs-plus"
@@ -40,9 +41,12 @@ class InsertLinkView extends View
       @updateSearch(@searchEditor.getText()) if posts
     @searchResult.on "click", "li", (e) => @useSearchResult(e)
 
-    atom.commands.add @element,
-      "core:confirm": => @onConfirm()
-      "core:cancel": => @detach()
+    @disposables = new CompositeDisposable()
+    @disposables.add(atom.commands.add(
+      @element, {
+        "core:confirm": => @onConfirm(),
+        "core:cancel":  => @detach()
+      }))
 
   onConfirm: ->
     link =
@@ -77,6 +81,10 @@ class InsertLinkView extends View
       @panel.hide()
       @previouslyFocusedElement?.focus()
     super
+
+  detached: ->
+    @disposables?.dispose()
+    @disposables = null
 
   _normalizeSelectionAndSetLinkFields: ->
     @range = utils.getTextBufferRange(@editor, "link")

--- a/lib/views/insert-table-view.coffee
+++ b/lib/views/insert-table-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {$, View, TextEditorView} = require "atom-space-pen-views"
 
 config = require "../config"
@@ -17,9 +18,12 @@ class InsertTableView extends View
   initialize: ->
     utils.setTabIndex([@rowEditor, @columnEditor])
 
-    atom.commands.add @element,
-      "core:confirm": => @onConfirm()
-      "core:cancel":  => @detach()
+    @disposables = new CompositeDisposable()
+    @disposables.add(atom.commands.add(
+      @element, {
+        "core:confirm": => @onConfirm(),
+        "core:cancel":  => @detach()
+      }))
 
   onConfirm: ->
     row = parseInt(@rowEditor.getText(), 10)
@@ -39,10 +43,14 @@ class InsertTableView extends View
     @rowEditor.focus()
 
   detach: ->
-    return unless @panel.isVisible()
-    @panel.hide()
-    @previouslyFocusedElement?.focus()
+    if @panel.isVisible()
+      @panel.hide()
+      @previouslyFocusedElement?.focus()
     super
+
+  detached: ->
+    @disposables?.dispose()
+    @disposables = null
 
   insertTable: (row, col) ->
     cursor = @editor.getCursorBufferPosition()

--- a/lib/views/manage-front-matter-view.coffee
+++ b/lib/views/manage-front-matter-view.coffee
@@ -1,3 +1,4 @@
+{CompositeDisposable} = require 'atom'
 {$, View, TextEditorView} = require "atom-space-pen-views"
 
 config = require "../config"
@@ -20,9 +21,12 @@ class ManageFrontMatterView extends View
   initialize: ->
     @candidates.on "click", "li", (e) => @appendFieldItem(e)
 
-    atom.commands.add @element,
-      "core:confirm": => @saveFrontMatter()
-      "core:cancel":  => @detach()
+    @disposables = new CompositeDisposable()
+    @disposables.add(atom.commands.add(
+      @element, {
+        "core:confirm": => @saveFrontMatter()
+        "core:cancel":  => @detach()
+      }))
 
   display: ->
     @editor = atom.workspace.getActiveTextEditor()
@@ -42,6 +46,10 @@ class ManageFrontMatterView extends View
       @panel.hide()
       @previouslyFocusedElement?.focus()
     super
+
+  detached: ->
+    @disposables?.dispose()
+    @disposables = null
 
   saveFrontMatter: ->
     @frontMatter.set(@constructor.fieldName, @getEditorFieldItems())


### PR DESCRIPTION
Add CompositeDisposable to views, to dispose atom.commands events after view detached.