### PR TITLE
Support footnote

### DIFF
--- a/lib/commands/jump-to.coffee
+++ b/lib/commands/jump-to.coffee
@@ -1,7 +1,7 @@
 utils = require "../utils"
 
 HEADING_REGEX   = /// ^\# {1,6} \ + .+$ ///
-REFERENCE_REGEX = /// \[? ([^\s\]]+) (?:\] | \]:)? ///
+REFERENCE_REGEX = /// \[? (\^? [^\s\]]+) (?: \] | \]:)? ///
 TABLE_COL_REGEX = /// ([^\|]*?) \s* \| ///
 
 module.exports =
@@ -48,13 +48,15 @@ class JumpTo
     return found
 
   referenceDefinition: ->
-    key = @editor.getSelectedText() || @editor.getWordUnderCursor()
-    return false unless key
+    range = utils.getTextBufferRange(@editor, "link")
+    selection = @editor.getTextInRange(range)
+    return false unless selection
 
-    key = utils.escapeRegExp(REFERENCE_REGEX.exec(key)[1])
+    link = REFERENCE_REGEX.exec(selection)
+    key = utils.escapeRegExp(link[1])
 
     found = false
-    @editor.buffer.scan /// \[ #{key} \] ///g, (match) =>
+    @editor.buffer.scan /// \[ \^? #{key} \] ///g, (match) =>
       end = match.range.end
       if end.row != @cursor.row
         found = [end.row, end.column - 1]

--- a/lib/config.cson
+++ b/lib/config.cson
@@ -144,6 +144,12 @@ referenceInsertPosition: "paragraph"
 # reference link tag indent space: 0, 2
 referenceIndentLength: 2
 
+# footnote tag template
+footnoteReferenceTag: "[^{label}]"
+footnoteDefinitionTag: "[^{label}]: {content}"
+# footnote definition tag insert position: "paragraph", "article"
+footnoteInsertPosition: "paragraph"
+
 # table default alignments: "empty", "left", "right", "center"
 tableAlignment: "empty"
 # insert extra pipes at the beginning and the end of table rows

--- a/lib/markdown-writer.coffee
+++ b/lib/markdown-writer.coffee
@@ -41,7 +41,7 @@ module.exports =
       editorCommands["markdown-writer:manage-post-#{attr}"] =
         @registerView("./views/manage-post-#{attr}-view")
 
-    ["link", "image", "table"].forEach (media) =>
+    ["link", "footnote", "image", "table"].forEach (media) =>
       editorCommands["markdown-writer:insert-#{media}"] =
         @registerView("./views/insert-#{media}-view")
 

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -367,6 +367,21 @@ parseReferenceDefinition = (input, editor) ->
     id: id, text: "", url: def[2], title: def[3] || "", linkRange: null
 
 # ==================================================
+# Footnote
+#
+
+FOOTNOTE_REGEX = /// \[ \^ (.+?) \] (:)? ///
+FOOTNOTE_TEST_REGEX = ///
+  #{OPEN_TAG}
+  #{FOOTNOTE_REGEX.source}
+  ///
+
+isFootnote = (input) -> FOOTNOTE_TEST_REGEX.test(input)
+parseFootnote = (input) ->
+  footnote = FOOTNOTE_REGEX.exec(input)
+  label: footnote[1], isDefinition: footnote[2] == ":", content: ""
+
+# ==================================================
 # Table
 #
 
@@ -563,17 +578,20 @@ getBufferRangeForScope = (editor, cursor, scopeSelector) ->
 # buffer range if it is inside a scope selector, or the current word.
 #
 # selection is optional, when not provided, use the last selection
-getTextBufferRange = (editor, scopeSelector, selection) ->
+# opts nearestWord select nearest word, true by default
+getTextBufferRange = (editor, scopeSelector, selection, opts = {}) ->
   selection ?= editor.getLastSelection()
   cursor = selection.cursor
 
   if selection.getText()
     selection.getBufferRange()
-  else if (scope = getScopeDescriptor(cursor, scopeSelector))
+  else if scope = getScopeDescriptor(cursor, scopeSelector)
     getBufferRangeForScope(editor, cursor, scope)
-  else
+  else if opts["nearestWord"] != false
     wordRegex = cursor.wordRegExp(includeNonWordCharacters: false)
     cursor.getCurrentWordBufferRange(wordRegex: wordRegex)
+  else
+    selection.getBufferRange()
 
 # ==================================================
 # Exports
@@ -612,6 +630,9 @@ module.exports =
   parseReferenceLink: parseReferenceLink
   isReferenceDefinition: isReferenceDefinition
   parseReferenceDefinition: parseReferenceDefinition
+
+  isFootnote: isFootnote
+  parseFootnote: parseFootnote
 
   isTableSeparator: isTableSeparator
   parseTableSeparator: parseTableSeparator

--- a/lib/views/insert-footnote-view.coffee
+++ b/lib/views/insert-footnote-view.coffee
@@ -1,0 +1,101 @@
+{CompositeDisposable} = require 'atom'
+{$, View, TextEditorView} = require "atom-space-pen-views"
+guid = require "guid"
+
+config = require "../config"
+utils = require "../utils"
+helper = require "../helpers/insert-link-helper"
+templateHelper = require "../helpers/template-helper"
+
+module.exports =
+class InsertFootnoteView extends View
+  @content: ->
+    @div class: "markdown-writer markdown-writer-dialog", =>
+      @label "Insert Footnote", class: "icon icon-pin"
+      @div =>
+        @label "Label", class: "message"
+        @subview "labelEditor", new TextEditorView(mini: true)
+      @div outlet: "contentBox", =>
+        @label "Content", class: "message"
+        @subview "contentEditor", new TextEditorView(mini: true)
+
+  initialize: ->
+    utils.setTabIndex([@labelEditor, @contentEditor])
+
+    @disposables = new CompositeDisposable()
+    @disposables.add(atom.commands.add(
+      @element, {
+        "core:confirm": => @onConfirm(),
+        "core:cancel":  => @detach()
+      }))
+
+  onConfirm: ->
+    footnote =
+      label: @labelEditor.getText()
+      content: @contentEditor.getText()
+
+    if @footnote
+      @updateFootnote(footnote)
+    else
+      @insertFootnote(footnote)
+
+    @detach()
+
+  display: ->
+    @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
+    @previouslyFocusedElement = $(document.activeElement)
+    @editor = atom.workspace.getActiveTextEditor()
+    @_normalizeSelectionAndSetFootnote()
+    @panel.show()
+    @labelEditor.getModel().selectAll()
+    @labelEditor.focus()
+
+  detach: ->
+    if @panel.isVisible()
+      @panel.hide()
+      @previouslyFocusedElement?.focus()
+    super
+
+  detached: ->
+    @disposables?.dispose()
+    @disposables = null
+
+  _normalizeSelectionAndSetFootnote: ->
+    @range = utils.getTextBufferRange(@editor, "link", null, nearestWord: false)
+    selection = @editor.getTextInRange(@range)
+
+    if utils.isFootnote(selection)
+      @footnote = utils.parseFootnote(selection)
+      @contentBox.hide()
+      @labelEditor.setText(@footnote["label"])
+    else
+      @labelEditor.setText(guid.raw()[0..7])
+
+  updateFootnote: (footnote) ->
+    referenceText = templateHelper.create("footnoteReferenceTag", footnote)
+    definitionText = templateHelper.create("footnoteDefinitionTag", footnote).trim()
+
+    if @footnote["isDefinition"]
+      updateText = definitionText
+      findText = templateHelper.create("footnoteReferenceTag", @footnote).trim()
+      replaceText = referenceText
+    else
+      updateText = referenceText
+      findText = templateHelper.create("footnoteDefinitionTag", @footnote).trim()
+      replaceText = definitionText
+
+    @editor.setTextInBufferRange(@range, updateText)
+    @editor.buffer.scan /// #{utils.escapeRegExp(findText)} ///, (match) ->
+      match.replace(replaceText)
+      match.stop()
+
+  insertFootnote: (footnote) ->
+    referenceText = templateHelper.create("footnoteReferenceTag", footnote)
+    definitionText = templateHelper.create("footnoteDefinitionTag", footnote).trim()
+
+    @editor.setTextInBufferRange(@range, referenceText)
+
+    if config.get("footnoteInsertPosition") == "article"
+      helper.insertAtEndOfArticle(@editor, definitionText)
+    else
+      helper.insertAfterCurrentParagraph(@editor, definitionText)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
       "markdown-writer:manage-post-tags",
       "markdown-writer:manage-post-categories",
       "markdown-writer:insert-link",
+      "markdown-writer:insert-footnote",
       "markdown-writer:insert-image",
       "markdown-writer:insert-table",
       "markdown-writer:toggle-code-text",

--- a/spec/commands/jump-to-spec.coffee
+++ b/spec/commands/jump-to-spec.coffee
@@ -96,6 +96,10 @@ describe "JumpTo", ->
     link to [content][]
 
     [content]: http://content
+
+    footnotes[^fn] is a special link
+
+    [^fn]: footnote definition
     """
 
     it "finds nothing if no word under cursor", ->
@@ -109,19 +113,31 @@ describe "JumpTo", ->
       jumpTo = new JumpTo()
       expect(jumpTo.referenceDefinition()).toBe(false)
 
-    it "finds link reference", ->
-      editor.setText(text)
-      editor.setCursorBufferPosition([2, 2])
+    describe "links", ->
+      beforeEach -> editor.setText(text)
 
-      jumpTo = new JumpTo()
-      expect(jumpTo.referenceDefinition()).toEqual([0, 16])
+      it "finds definition", ->
+        editor.setCursorBufferPosition([0, 16])
+        jumpTo = new JumpTo()
+        expect(jumpTo.referenceDefinition()).toEqual([2, 8])
 
-    it "finds link definition", ->
-      editor.setText(text)
-      editor.setCursorBufferPosition([0, 16])
+      it "finds reference", ->
+        editor.setCursorBufferPosition([2, 2])
+        jumpTo = new JumpTo()
+        expect(jumpTo.referenceDefinition()).toEqual([0, 16])
 
-      jumpTo = new JumpTo()
-      expect(jumpTo.referenceDefinition()).toEqual([2, 8])
+    describe "foonotes", ->
+      beforeEach -> editor.setText(text)
+
+      it "finds definition", ->
+        editor.setCursorBufferPosition([4, 12])
+        jumpTo = new JumpTo()
+        expect(jumpTo.referenceDefinition()).toEqual([6, 4])
+
+      it "finds reference", ->
+        editor.setCursorBufferPosition([6, 4])
+        jumpTo = new JumpTo()
+        expect(jumpTo.referenceDefinition()).toEqual([4, 13])
 
   describe ".nextTableCell", ->
     beforeEach ->

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -320,6 +320,30 @@ describe "utils", ->
         id: "id", text: "Jekyll", url: "http://jekyll.com", title: "Jekyll Website"
         linkRange: {start: {row: 5, column: 48}, end: {row: 5, column: 60}}
 
+  describe ".isFootnote", ->
+    it "check is text invalid footnote", ->
+      fixture = "[text]"
+      expect(utils.isFootnote(fixture)).toBe(false)
+      fixture = "![abc]"
+      expect(utils.isFootnote(fixture)).toBe(false)
+
+    it "check is text valid footnote", ->
+      fixture = "[^1]"
+      expect(utils.isFootnote(fixture)).toBe(true)
+      fixture = "[^text]"
+      expect(utils.isFootnote(fixture)).toBe(true)
+      fixture = "[^text text]"
+      expect(utils.isFootnote(fixture)).toBe(true)
+      fixture = "[^12]:"
+      expect(utils.isFootnote(fixture)).toBe(true)
+
+  describe ".parseFootnote", ->
+    it "parse valid footnote", ->
+      fixture = "[^1]"
+      expect(utils.parseFootnote(fixture)).toEqual(label: "1", content: "", isDefinition: false)
+      fixture = "[^text]: "
+      expect(utils.parseFootnote(fixture)).toEqual(label: "text", content: "", isDefinition: true)
+
 # ==================================================
 # Table
 #

--- a/spec/views/insert-footnote-view-spec.coffee
+++ b/spec/views/insert-footnote-view-spec.coffee
@@ -1,0 +1,72 @@
+InsertFootnoteView = require "../../lib/views/insert-footnote-view"
+
+describe "InsertFootnoteView", ->
+  [editor, insertFootnoteView] = []
+
+  beforeEach ->
+    waitsForPromise -> atom.workspace.open("empty.markdown")
+    runs ->
+      insertFootnoteView = new InsertFootnoteView({})
+      editor = atom.workspace.getActiveTextEditor()
+
+  describe ".display", ->
+    it "display without set footnote", ->
+      insertFootnoteView.display()
+      expect(insertFootnoteView.footnote).toBeUndefined()
+      expect(insertFootnoteView.labelEditor.getText().length).toEqual(8)
+
+    it "display with footnote set", ->
+      editor.setText "[^1]"
+      editor.setCursorBufferPosition([0, 0])
+      editor.selectToEndOfLine()
+
+      insertFootnoteView.display()
+      expect(insertFootnoteView.footnote).toEqual(label: "1", content: "", isDefinition: false)
+      expect(insertFootnoteView.labelEditor.getText()).toEqual("1")
+
+  describe ".insertFootnote", ->
+    it "insert footnote with content", ->
+      insertFootnoteView.display()
+      insertFootnoteView.insertFootnote(label: "footnote", content: "content")
+
+      expect(editor.getText()).toEqual """
+[^footnote]
+
+[^footnote]: content
+      """
+
+  describe ".updateFootnote", ->
+    fixture = """
+[^footnote]
+
+[^footnote]:
+content
+    """
+
+    expected = """
+[^note]
+
+[^note]:
+content
+    """
+
+    beforeEach ->
+      editor.setText(fixture)
+
+    it "update footnote definition to new label", ->
+      editor.setCursorBufferPosition([0, 0])
+      editor.selectToEndOfLine()
+
+      insertFootnoteView.display()
+      insertFootnoteView.updateFootnote(label: "note", content: "")
+
+      expect(editor.getText()).toEqual(expected)
+
+    it "update footnote reference to new label", ->
+      editor.setCursorBufferPosition([2, 0])
+      editor.selectToBufferPosition([2, 13])
+
+      insertFootnoteView.display()
+      insertFootnoteView.updateFootnote(label: "note", content: "")
+
+      expect(editor.getText()).toEqual(expected)


### PR DESCRIPTION
Support footnote:

- Insert footnote with single line content
- Update footnote label with selection or https://atom.io/packages/language-markdown (provides footnote highlights)
- Jump between footnotes