### PR TITLE
Support insert image from clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ More GIFs Here: [Create New Post](http://i.imgur.com/BwntxhB.gif), [Insert Refer
 - **Create new draft** with front matters ([setup required][ca8870d7]).
 - **Publish draft** moves a draft to post's directory with front matters (`date`, `published`) updated.
 - **Manage tags and categories** in front matters ([setup required][9be76601]).
-- **Site specific settings** ([view setup][1561ed4c]).
+- **Project/blog specific settings** ([view setup][1561ed4c]).
 
   [ca8870d7]: https://github.com/zhuochun/md-writer/wiki/Quick-Start "Markdown-Writer Setup Guide"
   [9be76601]: https://github.com/zhuochun/md-writer/wiki/Settings-for-Front-Matters "Setup Tags/Categories/Posts"
@@ -37,14 +37,15 @@ More GIFs Here: [Create New Post](http://i.imgur.com/BwntxhB.gif), [Insert Refer
 
 ### General
 
-- **Continue lists or table rows** when you press `enter` ([customize nested unorder list][adaa9527]).
+- **Continue lists or table rows** when you press `enter` ([customize][adaa9527]).
+  - **Correct ordered list numbers** (`markdown-writer:correct-order-list-numbers`).
 - **Insert link** (`shift-cmd-k`) and **automatically link to the text next time**.
   - Insert inline link.
   - Insert reference link with title. _Use `-` in title field to create an empty title reference link._
   - Remove link (and its reference) after URL is deleted.
   - Search published posts by title in your blog.
 - **Insert footnote** (`markdown-writer:insert-footnote`), and edit footnote labels.
-- **Insert image** (`shift-cmd-i`), auto-detect image height/width, and optionally copy images to your site's images directory.
+- **Insert image from file or clipboard** (`shift-cmd-i`), preview image and able to copy image to your blog's images directory.
 - **Insert table** (`markdown-writer:insert-table`), and quick **jump to next table cell** (`cmd-j cmd-t`).
 - **Format table** (`markdown-writer:format-table`) with table alignments.
 - **Toggle headings**: `ctrl-alt-[1-5]` to switch among `H1` to `H5`.
@@ -64,15 +65,14 @@ More GIFs Here: [Create New Post](http://i.imgur.com/BwntxhB.gif), [Insert Refer
   - Jump to next heading (`cmd-j cmd-n`)
   - Jump to next table cell (`cmd-j cmd-t`)
   - Jump to reference marker/definition (`cmd-j cmd-d`)
-- **Markdown cheat sheet** (`markdown-writer:open-cheat-sheet`).
-- **Correct order list numbers** (`markdown-writer:correct-order-list-numbers`).
 - **Open link under cursor in browser** (`markdown-writer:open-link-in-browser`), and works on reference links.
+- **Markdown cheat sheet** (`markdown-writer:open-cheat-sheet`).
 - **Toolbar for Markdown Writer** is available at [tool-bar-markdown-writer][82a2aced].
 - **AsciiDoc support** with [language-asciidoc][2f0cb1f9].
 
   [82a2aced]: https://atom.io/packages/tool-bar-markdown-writer "Toobar for Markdown Writer"
   [2f0cb1f9]: https://atom.io/packages/language-asciidoc "AsciiDoc Language Package for Atom"
-  [adaa9527]: https://github.com/zhuochun/md-writer/issues/154 "Customization on nested unorder list"
+  [adaa9527]: https://github.com/zhuochun/md-writer/wiki/Settings#use-different-unordered-list-styles "Customizations"
 
 You can find and trigger all features in:
 
@@ -88,7 +88,7 @@ You can find and trigger all features in:
 
 ## Setup
 
-Go to Settings (`cmd-,`) -> Packages -> `Markdown-Writer` -> Settings.
+Go to Settings (`cmd-,`) -> Packages -> Markdown-Writer -> Settings.
 
 > If you do not see any settings (due to a [Atom's bug][3ecd2daa]), please activate Markdown-Writer using command (e.g. `Open Cheat Sheet`). Close and reopen the Settings page.
 

--- a/lib/commands/insert-image.coffee
+++ b/lib/commands/insert-image.coffee
@@ -1,0 +1,14 @@
+clipboard = require 'clipboard'
+
+InsertImageFileView = require "../views/insert-image-file-view"
+InsertImageClipboardView = require "../views/insert-image-clipboard-view"
+
+module.exports =
+class InsertImage
+  trigger: (e) ->
+    if clipboard.readImage().isEmpty()
+      view = new InsertImageFileView()
+      view.display()
+    else
+      view = new InsertImageClipboardView()
+      view.display()

--- a/lib/markdown-writer.coffee
+++ b/lib/markdown-writer.coffee
@@ -40,7 +40,7 @@ module.exports =
       editorCommands["markdown-writer:manage-post-#{attr}"] =
         @registerView("./views/manage-post-#{attr}-view")
 
-    ["link", "footnote", "image", "table"].forEach (media) =>
+    ["link", "footnote", "image-file", "image-clipboard", "table"].forEach (media) =>
       editorCommands["markdown-writer:insert-#{media}"] =
         @registerView("./views/insert-#{media}-view")
 
@@ -65,7 +65,7 @@ module.exports =
       editorCommands["markdown-writer:#{command}"] =
         @registerCommand("./commands/format-text", args: command)
 
-    ["publish-draft", "open-link-in-browser"].forEach (command) =>
+    ["publish-draft", "open-link-in-browser", "insert-image"].forEach (command) =>
       editorCommands["markdown-writer:#{command}"] =
         @registerCommand("./commands/#{command}")
 

--- a/lib/views/insert-image-clipboard-view.coffee
+++ b/lib/views/insert-image-clipboard-view.coffee
@@ -1,0 +1,175 @@
+{CompositeDisposable} = require 'atom'
+{$, View, TextEditorView} = require "atom-space-pen-views"
+path = require "path"
+fs = require "fs-plus"
+clipboard = require 'clipboard'
+
+config = require "../config"
+utils = require "../utils"
+templateHelper = require "../helpers/template-helper"
+
+module.exports =
+class InsertImageClipboardView extends View
+  @content: ->
+    @div class: "markdown-writer markdown-writer-dialog", =>
+      @label "Insert Image from Clipboard", class: "icon icon-clippy"
+      @div =>
+        @label "Title (alt)", class: "message"
+        @subview "titleEditor", new TextEditorView(mini: true)
+        @div class: "col-1", =>
+          @label "Width (px)", class: "message"
+          @subview "widthEditor", new TextEditorView(mini: true)
+        @div class: "col-1", =>
+          @label "Height (px)", class: "message"
+          @subview "heightEditor", new TextEditorView(mini: true)
+        @div class: "col-2", =>
+          @label "Alignment", class: "message"
+          @subview "alignEditor", new TextEditorView(mini: true)
+      @div class: "dialog-row", =>
+        @span "Save Image To: Missing Title (alt)", outlet: "copyImageMessage"
+      @div class: "image-container", =>
+        @img outlet: 'imagePreview'
+
+  initialize: ->
+    utils.setTabIndex([@titleEditor, @widthEditor, @heightEditor, @alignEditor])
+
+    @titleEditor.on "keyup", => @updateCopyImageDest()
+
+    @disposables = new CompositeDisposable()
+    @disposables.add(atom.commands.add(
+      @element, {
+        "core:confirm": => @onConfirm(),
+        "core:cancel":  => @detach()
+      }))
+
+  onConfirm: ->
+    title = @titleEditor.getText().trim()
+    return unless title
+
+    try
+      destFile = @getCopiedImageDestPath(title)
+
+      if fs.existsSync(destFile)
+        confirmation = atom.confirm
+          message: "File already exists!"
+          detailedMessage: "Another file already exists at:\n#{destFile}\nDo you want to overwrite it?"
+          buttons: ["No", "Yes"]
+        # abort overwrite and edit title
+        if confirmation == 0
+          @titleEditor.focus()
+          return
+
+      fs.writeFileSync(destFile, @clipboardImage.toPng())
+      # write dest path to clipboard
+      clipboard.writeText(destFile)
+
+      @editor.transact => @insertImageTag(destFile)
+      @detach()
+    catch error
+      atom.confirm
+        message: "[Markdown Writer] Error!"
+        detailedMessage: "Saving Image:\n#{error.message}"
+        buttons: ['OK']
+
+  display: ->
+    # read image from clipboard
+    @clipboardImage = clipboard.readImage()
+    return if @clipboardImage.isEmpty()
+    # display view
+    @panel ?= atom.workspace.addModalPanel(item: this, visible: false)
+    @previouslyFocusedElement = $(document.activeElement)
+    @editor = atom.workspace.getActiveTextEditor()
+    @frontMatter = templateHelper.getEditor(@editor)
+    @dateTime = templateHelper.getDateTime()
+    # initialize view
+    @setImageContext()
+    @displayImagePreview()
+    # show view
+    @panel.show()
+    @titleEditor.focus()
+
+  detach: ->
+    if @panel.isVisible()
+      @panel.hide()
+      @previouslyFocusedElement?.focus()
+    super
+
+  detached: ->
+    @disposables?.dispose()
+    @disposables = null
+
+  setImageContext: ->
+    { width, height } = @clipboardImage.getSize()
+    @widthEditor.setText("" + width)
+    @heightEditor.setText("" + height)
+
+    position = if width > 300 then "center" else "right"
+    @alignEditor.setText(position)
+
+  updateCopyImageDest: ->
+    title = @titleEditor.getText().trim()
+    if title
+      destFile = @getCopiedImageDestPath(title)
+      @copyImageMessage.text("Save Image To: #{destFile}")
+    else
+      @copyImageMessage.text("Save Image To: Missing Title (alt)")
+
+  displayImagePreview: ->
+    @imagePreview.attr("src", @clipboardImage.toDataURL())
+    @imagePreview.error -> console.log("Error: Failed to Load Image.")
+
+  insertImageTag: (imgSource) ->
+    img =
+      rawSrc: imgSource,
+      src: @generateImageSrc(imgSource)
+      relativeFileSrc: @generateRelativeImageSrc(imgSource, @currentFileDir())
+      relativeSiteSrc: @generateRelativeImageSrc(imgSource, @siteLocalDir())
+      alt: @titleEditor.getText()
+      width: @widthEditor.getText()
+      height: @heightEditor.getText()
+      align: @alignEditor.getText()
+
+    # insert image tag when img.src exists, otherwise consider the image was removed
+    if img.src
+      text = templateHelper.create("imageTag", @frontMatter, @dateTime, img)
+    else
+      text = img.alt
+
+    @editor.insertText(text)
+
+  # get user's site local directory
+  siteLocalDir: -> utils.getSitePath(config.get("siteLocalDir"))
+  # get user's site images directory
+  siteImagesDir: -> templateHelper.create("siteImagesDir", @frontMatter, @dateTime)
+  # get current open file directory
+  currentFileDir: -> path.dirname(@editor.getPath() || "")
+  # check the file is in the site directory
+  isInSiteDir: (file) -> file && file.startsWith(@siteLocalDir())
+
+  # get copy image destination file path
+  getCopiedImageDestPath: (title) ->
+    extension = ".png"
+    title = (new Date()).toISOString().replace(/[:\.]/g, "-") unless title
+    title = utils.slugize(title, config.get('slugSeparator'))
+    filename = "#{title}#{extension}"
+    path.join(@siteLocalDir(), @siteImagesDir(), filename)
+
+  # generate a src that is used in markdown file based on user configuration or file location
+  generateImageSrc: (file) ->
+    utils.normalizeFilePath(@_generateImageSrc(file))
+
+  _generateImageSrc: (file) ->
+    return "" unless file
+    return file if utils.isUrl(file)
+    return path.relative(@currentFileDir(), file) if config.get('relativeImagePath')
+    return path.relative(@siteLocalDir(), file) if @isInSiteDir(file)
+    return path.join("/", @siteImagesDir(), path.basename(file))
+
+  # generate a relative src from the base path or from user's home directory
+  generateRelativeImageSrc: (file, basePath) ->
+    utils.normalizeFilePath(@_generateRelativeImageSrc(file, basePath))
+
+  _generateRelativeImageSrc: (file, basePath) ->
+    return "" unless file
+    return file if utils.isUrl(file)
+    return path.relative(basePath || "~", file)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
       "markdown-writer:insert-link",
       "markdown-writer:insert-footnote",
       "markdown-writer:insert-image",
+      "markdown-writer:insert-image-file",
+      "markdown-writer:insert-image-clipboard",
       "markdown-writer:insert-table",
       "markdown-writer:toggle-code-text",
       "markdown-writer:toggle-codeblock-text",

--- a/spec/views/insert-image-file-view-spec.coffee
+++ b/spec/views/insert-image-file-view-spec.coffee
@@ -1,7 +1,7 @@
 config = require "../../lib/config"
-InsertImageView = require "../../lib/views/insert-image-view"
+InsertImageFileView = require "../../lib/views/insert-image-file-view"
 
-describe "InsertImageView", ->
+describe "InsertImageFileView", ->
   [editor, insertImageView] = []
 
   beforeEach ->
@@ -9,7 +9,7 @@ describe "InsertImageView", ->
 
     runs ->
       editor = atom.workspace.getActiveTextEditor()
-      insertImageView = new InsertImageView({})
+      insertImageView = new InsertImageFileView({})
 
   describe ".isInSiteDir", ->
     beforeEach ->
@@ -45,23 +45,23 @@ describe "InsertImageView", ->
       expected = editor.getPath().replace("empty.markdown", "octocat.png")
       expect(insertImageView.resolveImagePath(fixture)).toBe(expected)
 
-  describe ".copyImageDestPath", ->
+  describe ".getCopiedImageDestPath", ->
     it "return the local path with original filename", ->
       atom.config.set("markdown-writer.renameImageOnCopy", false)
       fixture = "images/icons/emoji/octocat.png"
-      expect(insertImageView.copyImageDestPath(fixture, "name")).toMatch(/[\/\\]octocat\.png/)
+      expect(insertImageView.getCopiedImageDestPath(fixture, "name")).toMatch(/[\/\\]octocat\.png/)
 
     it "return the local path with new filename", ->
       atom.config.set("markdown-writer.renameImageOnCopy", true)
       # normal case
       fixture = "images/icons/emoji/octocat.png"
-      expect(insertImageView.copyImageDestPath(fixture, "New name")).toMatch(/[\/\\]new-name\.png/)
+      expect(insertImageView.getCopiedImageDestPath(fixture, "New name")).toMatch(/[\/\\]new-name\.png/)
       # no extension
       fixture = "images/icons/emoji/octocat"
-      expect(insertImageView.copyImageDestPath(fixture, "New name")).toMatch(/[\/\\]new-name/)
+      expect(insertImageView.getCopiedImageDestPath(fixture, "New name")).toMatch(/[\/\\]new-name/)
       # no alt text set
       fixture = "images/icons/emoji/octocat.png"
-      expect(insertImageView.copyImageDestPath(fixture, "")).toMatch(/[\/\\]octocat.png/)
+      expect(insertImageView.getCopiedImageDestPath(fixture, "")).toMatch(/[\/\\]octocat.png/)
 
   describe ".generateImageSrc", ->
     it "return empty image path", ->


### PR DESCRIPTION
Related #159 

Commands:

- **markdown-writer:insert-image**: replaced the original command, and will choose to use `FileView` or `ClipboardView`
- **markdown-writer:insert-image-file**: the original insert image view
- **markdown-writer:insert-image-clipboard**: new insert image from clipboard view