### PR TITLE
Add custom front matter fields

### DIFF
--- a/lib/config.cson
+++ b/lib/config.cson
@@ -43,6 +43,11 @@ newDraftFileName: "{slug}{extension}"
 # Filename format of new posts created
 newPostFileName: "{year}-{month}-{day}-{slug}{extension}"
 
+# Front matter add custom fields
+# - Configured as a key-value pair (fieldName: defaultValue)
+# - Referenced by fieldName
+# frontMatterCustomFields:
+#   author: "Your Name Here"
 # Front matter date format, determines the {date} in frontMatter
 frontMatterDate: "{year}-{month}-{day} {hour}:{minute}"
 # Front matter template

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -15,6 +15,10 @@ escapeRegExp = (str) ->
   return "" unless str
   str.replace(/[-\/\\^$*+?.()|[\]{}]/g, "\\$&")
 
+capitalize = (str) ->
+  return "" unless str
+  str.replace /^[a-z]/, (c) -> c.toUpperCase()
+
 isUpperCase = (str) ->
   if str.length > 0 then (str[0] >= 'A' && str[0] <= 'Z')
   else false
@@ -648,6 +652,7 @@ findLinkInRange = (editor, range) ->
 module.exports =
   getJSON: getJSON
   escapeRegExp: escapeRegExp
+  capitalize: capitalize
   isUpperCase: isUpperCase
   incrementChars: incrementChars
   slugize: slugize

--- a/lib/views/new-file-view.coffee
+++ b/lib/views/new-file-view.coffee
@@ -66,7 +66,7 @@ class NewFileView extends View
     @previouslyFocusedElement = $(document.activeElement)
     @dateEditor.setText(templateHelper.getFrontMatterDate(@dateTime))
     @pathEditor.setText(templateHelper.create(@constructor.pathConfig, @dateTime))
-    @[f["editor"]].setText(f["value"]) if f["value"] for f in @constructor.getCustomFields()
+    @[f["editor"]].setText(f["value"]) for f in @constructor.getCustomFields() when !!f["value"]
     @panel.show()
     @titleEditor.focus()
 

--- a/lib/views/new-file-view.coffee
+++ b/lib/views/new-file-view.coffee
@@ -23,11 +23,27 @@ class NewFileView extends View
         @subview "dateEditor", new TextEditorView(mini: true)
         @label "Title", class: "message"
         @subview "titleEditor", new TextEditorView(mini: true)
+        # render custom fields
+        for f in @getCustomFields()
+          @label f["name"], class: "message"
+          @subview f["editor"], new TextEditorView(mini: true)
+
       @p class: "message", outlet: "message"
       @p class: "error", outlet: "error"
 
+  # custom fields
+  @getCustomFields: ->
+    for field, value of config.get("frontMatterCustomFields") || {}
+      id: utils.slugize(field)
+      editor: "#{utils.slugize(field)}CustomEditor"
+      name: utils.capitalize(field)
+      value: value
+
   initialize: ->
-    utils.setTabIndex([@titleEditor, @pathEditor, @dateEditor])
+    editors = [@titleEditor, @pathEditor, @dateEditor]
+    editors.push(@[f["editor"]]) for f in @constructor.getCustomFields()
+    # set tab orders
+    utils.setTabIndex(editors)
 
     # save current date time as base
     @dateTime = templateHelper.getDateTime()
@@ -50,6 +66,7 @@ class NewFileView extends View
     @previouslyFocusedElement = $(document.activeElement)
     @dateEditor.setText(templateHelper.getFrontMatterDate(@dateTime))
     @pathEditor.setText(templateHelper.create(@constructor.pathConfig, @dateTime))
+    @[f["editor"]].setText(f["value"]) if f["value"] for f in @constructor.getCustomFields()
     @panel.show()
     @titleEditor.focus()
 
@@ -97,4 +114,8 @@ class NewFileView extends View
 
   getFileName: -> templateHelper.create(@constructor.fileNameConfig, @getFrontMatter(), @getDateTime())
   getDateTime: -> templateHelper.parseFrontMatterDate(@dateEditor.getText()) || @dateTime
-  getFrontMatter: -> templateHelper.getFrontMatter(this)
+  getFrontMatter: ->
+    base = templateHelper.getFrontMatter(this)
+    # add custom fields to frontMatter
+    base[f["id"]] = @[f["editor"]].getText() for f in @constructor.getCustomFields()
+    base

--- a/spec/utils-spec.coffee
+++ b/spec/utils-spec.coffee
@@ -6,6 +6,12 @@ describe "utils", ->
 # ==================================================
 # General Utils
 #
+  describe ".capitalize", ->
+    it "capitalize string", ->
+      expect(utils.capitalize("")).toEqual("")
+      expect(utils.capitalize("Author")).toEqual("Author")
+      expect(utils.capitalize("authorName")).toEqual("AuthorName")
+      expect(utils.capitalize("中文")).toEqual("中文")
 
   describe ".incrementChars", ->
     it "increment empty chars", ->


### PR DESCRIPTION
Support #219. Usage:

1. Add new config `frontMatterCustomFields`
  - key-value pair (fieldName: defaultValue), referenced by fieldName in template
2. Add the field to template

```
frontMatterCustomFields:
  author: "Your Name Here"

# Front matter template
frontMatter: """
 ---
 layout: "{layout}"
 title: "{title}"
 author: "{author}"
 date: "{date}"
 ---
"""
```