### PR TITLE
Add new command fold-links

### DIFF
--- a/lib/commands/fold-text.coffee
+++ b/lib/commands/fold-text.coffee
@@ -1,0 +1,16 @@
+config = require "../config"
+utils = require "../utils"
+
+module.exports =
+class FoldText
+  # action: fold-links
+  constructor: (action) ->
+    @action = action
+    @editor = atom.workspace.getActiveTextEditor()
+
+  trigger: (e) ->
+    fn = @action.replace /-[a-z]/ig, (s) -> s[1].toUpperCase()
+    @[fn]()
+
+  foldLinks: ->
+    utils.scanLinks @editor, (range) => @editor.foldBufferRange(range)

--- a/lib/markdown-writer.coffee
+++ b/lib/markdown-writer.coffee
@@ -67,6 +67,10 @@ module.exports =
       editorCommands["markdown-writer:#{command}"] =
         @registerCommand("./commands/format-text", args: command)
 
+    ["fold-links"].forEach (command) =>
+      editorCommands["markdown-writer:#{command}"] =
+        @registerCommand("./commands/fold-text", args: command)
+
     ["publish-draft", "open-link-in-browser", "insert-image"].forEach (command) =>
       editorCommands["markdown-writer:#{command}"] =
         @registerCommand("./commands/#{command}")

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -302,6 +302,13 @@ parseInlineLink = (input) ->
   else
     text: input, url: "", title: ""
 
+scanLinks = (editor, cb) ->
+  editor.buffer.scan /// #{INLINE_LINK_REGEX.source} ///g, (match) ->
+    rg = match.range
+    rg.start.column += match.match[1].length + 3 # [](
+    rg.end.column -= 1
+    cb(rg)
+
 # ==================================================
 # Reference link
 #
@@ -672,6 +679,7 @@ module.exports =
   isImage: isImage
   parseImage: parseImage
 
+  scanLinks: scanLinks
   isInlineLink: isInlineLink
   parseInlineLink: parseInlineLink
   isReferenceLink: isReferenceLink

--- a/menus/menu.cson
+++ b/menus/menu.cson
@@ -100,8 +100,6 @@
               'label': 'highlight',
               'command': 'markdown-writer:toggle-highlight-text'
             }
-
-
             { 'type': 'separator' }
             {
               'label': 'Heading 1'
@@ -162,6 +160,19 @@
           ]
         }
         {
+          'label': 'Folding'
+          'submenu': [
+            {
+              'label': 'Fold All Links'
+              'command': 'markdown-writer:fold-links'
+            }
+            {
+              'label': 'Unfold All'
+              'command': 'editor:unfold-all'
+            }
+          ]
+        }
+        {
           'label': 'Helpers'
           'submenu': [
             {
@@ -176,6 +187,11 @@
             {
               'label': 'Jump to Link/Definition'
               'command': 'markdown-writer:jump-to-reference-definition'
+            }
+            { 'type': 'separator' }
+            {
+              'label': 'Fold All Links'
+              'command': 'markdown-writer:fold-links'
             }
             { 'type': 'separator' }
             {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "markdown-writer:jump-to-reference-definition",
       "markdown-writer:publish-draft",
       "markdown-writer:open-link-in-browser",
+      "markdown-writer:fold-links",
       "markdown-writer:format-table",
       "markdown-writer:correct-order-list-numbers",
       "markdown-writer:insert-new-line",


### PR DESCRIPTION
New command `markdown-writer:fold-links` to fold inline links. Use default `editor:unfold-all` to unfold all.

E.g.

![image](https://user-images.githubusercontent.com/842419/43359909-6b640b4c-92de-11e8-8c51-1b74131e3d26.png)


