### PR TITLE
Support different text selection range config

### DIFF
--- a/lib/commands/style-text.coffee
+++ b/lib/commands/style-text.coffee
@@ -2,11 +2,8 @@ config = require "../config"
 utils = require "../utils"
 
 # Map markdown-writer text style keys to official gfm style scope selectors
-scopeSelectors =
-  code: ".raw"
-  bold: ".bold"
-  italic: ".italic"
-  strikethrough: ".strike"
+# DEPRECATED use config.textStyles.{style}.scopeSelector instead
+scopeSelectors = code: ".raw", bold: ".bold", italic: ".italic", strikethrough: ".strike"
 
 module.exports =
 class StyleText
@@ -16,6 +13,8 @@ class StyleText
   # - after (required)
   # - regexBefore (optional) overwrites before when to match/replace string
   # - regexAfter (optional) overwrites after when to match/replace string
+  # - scopeSelector (optional) defines an gfm style scope selectors
+  # - selectBy (option) empty or "nearestWord"
   #
   constructor: (style) ->
     @styleName = style
@@ -38,10 +37,12 @@ class StyleText
 
   # try to act smart to correct the selection if needed
   normalizeSelection: (selection) ->
-    scopeSelector = scopeSelectors[@styleName]
-    return unless scopeSelector
+    scopeSelector = @style.scopeSelector || scopeSelectors[@styleName]
+    opts =
+      selection: selection,
+      selectBy: @style.selectBy || config.get("textRangeSelectBy")
 
-    range = utils.getTextBufferRange(@editor, scopeSelector, selection)
+    range = utils.getTextBufferRange(@editor, scopeSelector, opts)
     selection.setBufferRange(range)
 
   toggleStyle: (selection, text, opts) ->

--- a/lib/config.cson
+++ b/lib/config.cson
@@ -86,50 +86,75 @@ tableNewLineContinuation: true
 #   under your Atom global config directory
 # siteLinkPath: "set/path/to/links.cson"
 
-# TextStyles and LineStyles
+# Default text range selection, can be overwritten individually in textStyles:
 #
-# - Use `before` and `after` to insert text around the selected text.
-# - Use `regexMatch{Before,After}` when an exact match of the style is needed.
-#   If this regex matched true, the style will be toggled.
-# - Use `regex{Before,After}` when a general match of the style is wanted.
-#   If this regex matched true, the style will be replaced by new style.
+# - "nope" (disabled), "nearestWord" (alphanum word, default), "currentWord",
+#   "currentNonTrailWord" (current word except at the end of a word),
+#   "currentLine", "currentParagraph"
+#
+textRangeSelectBy: "nearestWord"
+
+# TextStyles adjust text/word styles
+#
+# - Use `before` and `after` to define insert characters around the selected text.
+# - Use `regex{Before,After}` (optional) to define a regex match of any similar style.
+#   If this regex is matched, the matched style will be replaced by this style.
 #
 # NOTE
 #
-# - In `regex{Before,After}`, `regexMatch{Before,After}`, DO NOT USE CAPTURE GROUP!
-#   Capture group will break things! USE non-capturing group `(?:)` instead.
-# - When `regexMatch{Before,After}` is not specified, `regex{Before,After}` is used instead.
-# - In nested settings, e.g. codeblock, ul, ol, all the within nested keys need to exists if
-#   you changed one setting.
+# - DO NOT USE CAPTURE GROUP IN `regex{Before,After}`! Capture group break things,
+#   use non-capturing group `(?:)` instead.
+# - When you modify one style, make sure all configurations for this style are present.
+#   E.g. when you modify italic.before and italic.after, keep italic.scopeSelector intact.
+# - If you don't plan to modify any of these settings, remove them. So the settings
+#   fallback to defaults and enjoy updates when the package is upgraded.
 #
 textStyles:
   code:
-    before: "`", after: "`"
+    before: "`", after: "`", scopeSelector: ".raw"
   bold:
-    before: "**", after: "**"
+    before: "**", after: "**", scopeSelector: ".bold"
   italic:
-    before: "_", after: "_"
+    before: "_", after: "_", scopeSelector: ".italic"
   keystroke:
     before: "<kbd>", after: "</kbd>"
   strikethrough:
-    before: "~~", after: "~~"
+    before: "~~", after: "~~", scopeSelector: ".strike"
   codeblock:
     before: "```\n"
     after: "\n```"
     regexBefore: "```(?:[\\w- ]+)?\\r?\\n"
     regexAfter: "\\r?\\n```"
+    selectBy: "currentParagraph"
   deletion:
-    before: "{--", after: "--}"
+    before: "{--", after: "--}", scopeSelector: "critic."
   addition:
-    before: "{++", after: "++}"
+    before: "{++", after: "++}", scopeSelector: "critic."
   substitution:
     before: "{~~", after: "~>~~}"
   comment:
-    before: "{>>", after: "<<}"
+    before: "{>>", after: "<<}", scopeSelector: "critic."
   highlight:
     before: "{==", after: "==}{>><<}"
 
-
+# LineStyles adjust line/sentence styles
+#
+# - Use `before` and `after` to define insert characters around the selected text.
+# - Use `regex{Before,After}` (optional) to define a regex match of any similar style.
+#   If this regex is matched, the matched style will be replaced by this style.
+# - Use `regexMatch{Before,After}` (optional) to define an exact match of this style.
+#   If this regex is matched, this style will be toggled. This config takes the highest
+#   matching priority.
+#
+# NOTE
+#
+# - DO NOT USE CAPTURE GROUP IN `regex{Before,After}`, `regexMatch{Before,After}`!
+#    Capture group break things, use non-capturing group `(?:)` instead.
+# - When you modify one style, make sure all configurations for this style are present.
+#   E.g. when you modify ul.before, keep ul.regexMatchBefore etc intact.
+# - If you don't plan to modify any of these settings, remove them. So the settings
+#   fallback to defaults and enjoy updates when the package is upgraded.
+#
 lineStyles:
   h1: before: "# "
   h2: before: "## "

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -576,8 +576,9 @@ getScopeDescriptor = (cursor, scopeSelector) ->
     return scopes[0]
 
 getBufferRangeForScope = (editor, cursor, scopeSelector) ->
-  pos = cursor.getBufferPosition()
+  return unless scopeSelector # remove undefined scopeSelector
 
+  pos = cursor.getBufferPosition()
   range = editor.bufferRangeForScopeAtPosition(scopeSelector, pos)
   return range if range
 
@@ -600,19 +601,15 @@ getBufferRangeForScope = (editor, cursor, scopeSelector) ->
 # Get the text buffer range if selection is not empty, or get the
 # buffer range if it is inside a scope selector, or the current word.
 #
-# selection: optional, when not provided or empty, use the last selection
+# opts["selection"]: optional, when not provided or empty, use the last selection
 # opts["selectBy"]:
 #  - nope: do not use any select by
 #  - nearestWord: try select nearest word, default
 #  - currentLine: try select current line
-getTextBufferRange = (editor, scopeSelector, selection, opts = {}) ->
-  if typeof(selection) == "object"
-    opts = selection
-    selection = undefined
-
-  selection ?= editor.getLastSelection()
+getTextBufferRange = (editor, scopeSelector, opts = {}) ->
+  selection = opts.selection || editor.getLastSelection()
+  selectBy = opts.selectBy || "nearestWord"
   cursor = selection.cursor
-  selectBy = opts["selectBy"] || "nearestWord"
 
   if selection.getText()
     selection.getBufferRange()
@@ -621,8 +618,19 @@ getTextBufferRange = (editor, scopeSelector, selection, opts = {}) ->
   else if selectBy == "nearestWord"
     wordRegex = cursor.wordRegExp(includeNonWordCharacters: false)
     cursor.getCurrentWordBufferRange(wordRegex: wordRegex)
+  else if selectBy == "currentWord"
+    cursor.getCurrentWordBufferRange()
+  else if selectBy == "currentNonTrailWord"
+    wordRange = cursor.getCurrentWordBufferRange()
+    # test if cursor is at the end of word
+    if wordRange.end.column == cursor.getBufferColumn()
+      selection.getBufferRange()
+    else
+      wordRange
   else if selectBy == "currentLine"
     cursor.getCurrentLineBufferRange()
+  else if selectBy == "currentParagraph"
+    cursor.getCurrentParagraphBufferRange()
   else
     selection.getBufferRange()
 


### PR DESCRIPTION
Add global default config `textRangeSelectBy: "nearestWord"` and individual text style `selectBy` config.

To addresses #143 , change to use `currentNonTrailWord`.

The accuracy still depends on word definition by Atom.