### PR TITLE
Fix style line that spans multiple screen lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.10.2
+
+* Fix style line that spans multiple screen lines ([#257](https://github.com/zhuochun/md-writer/issues/257))
+
 ## 2.10.1
 
 * Fix style multiple lines ([#256](https://github.com/zhuochun/md-writer/pull/256))
@@ -35,7 +39,7 @@
 
 ## 2.7.3
 
-* Fix indent list that spans multiple lines
+* Fix indent list that spans multiple screen lines [#222](https://github.com/zhuochun/md-writer/issues/222)
 
 ## 2.7.2
 

--- a/lib/commands/style-line.coffee
+++ b/lib/commands/style-line.coffee
@@ -123,7 +123,7 @@ class StyleLine
 
     # replace text in line
     selection.cursor.setBufferPosition([position.row, 0])
-    selection.selectToEndOfLine()
+    selection.selectToEndOfBufferLine()
     selection.insertText("#{match[1]}#{newBefore}#{match[3]}#{newAfter}#{match[5]}")
 
     # recover original position in the new text

--- a/spec/commands/style-line-spec.coffee
+++ b/spec/commands/style-line-spec.coffee
@@ -13,6 +13,15 @@ describe "StyleLine", ->
       expect(editor.getText()).toBe("> ")
       expect(editor.getCursorBufferPosition().column).toBe(2)
 
+    it "insert blockquote in long text", ->
+      text = "3. Consider a (ordered or unordered) markdown list. On apply style to the line, if the item spans over more than one line, then the text of the item alters. See the below gif in https://github.com/zhuochun/md-writer/issues/257"
+      editor.setText(text)
+      editor.setCursorBufferPosition([0, 4])
+
+      new StyleLine("blockquote").trigger()
+      expect(editor.getText()).toBe("> #{text}")
+      expect(editor.getCursorBufferPosition().column).toBe(6)
+
     it "remove blockquote", ->
       editor.setText("> blockquote")
       editor.setCursorBufferPosition([0, 4])


### PR DESCRIPTION
Fixes #257

- `::selectToEndOfLine()` -> Selects all the text from the current cursor position to the end of the **screen line**.
- `::selectToEndOfBufferLine()` -> Selects all the text from the current cursor position to the end of the **buffer line**.