### PR TITLE
Add empty lines to TOC comment tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ More GIFs Here: [Create New Post](http://i.imgur.com/BwntxhB.gif), [Insert Refer
   <summary><strong>Table of Contents</strong> (click to expand)</summary>
 
 <!-- TOC depthFrom:2 -->
+
 - [Features](#features)
   - [Blogging](#blogging)
   - [General](#general)
@@ -25,6 +26,7 @@ More GIFs Here: [Create New Post](http://i.imgur.com/BwntxhB.gif), [Insert Refer
 - [Setup](#setup)
 - [Contributing](#contributing)
 - [Project](#project)
+
 <!-- /TOC -->
 </details>
 

--- a/lib/commands/edit-toc.coffee
+++ b/lib/commands/edit-toc.coffee
@@ -62,7 +62,11 @@ class EditToc
     else
       lines.push("<!-- TOC -->")
 
+    lines.push("") # empty separator
+
   _writeTocTail: (lines, toc) ->
+    lines.push("") # empty separator
+
     if toc.found
       lines.push(toc.tail.text)
     else

--- a/spec/commands/edit-toc-spec.coffee
+++ b/spec/commands/edit-toc-spec.coffee
@@ -22,6 +22,8 @@ describe "EditTOC", ->
       editTOC.trigger()
       expect(editor.getText()).toBe """
       <!-- TOC -->
+
+
       <!-- /TOC -->
 
       this is a sentence
@@ -57,6 +59,7 @@ describe "EditTOC", ->
       # Markdown-Writer for Atom
 
       <!-- TOC -->
+
       - [Markdown-Writer for Atom](#markdown-writer-for-atom)
         - [Features](#features)
           - [Blogging](#blogging)
@@ -65,6 +68,7 @@ describe "EditTOC", ->
         - [Setup](#setup)
         - [Contributing](#contributing)
         - [Project](#project)
+
       <!-- /TOC -->
 
       ## Features
@@ -87,6 +91,7 @@ describe "EditTOC", ->
       # Markdown-Writer for Atom
 
       <!-- TOC depthFrom:2 -->
+
       - [Markdown-Writer for Atom](#markdown-writer-for-atom)
         - [Features](#features)
           - [Blogging](#blogging)
@@ -95,6 +100,7 @@ describe "EditTOC", ->
         - [Setup](#setup)
         - [Contributing](#contributing)
         - [Project](#project)
+
       <!-- /TOC -->
 
       ## Features
@@ -118,6 +124,7 @@ describe "EditTOC", ->
       # Markdown-Writer for Atom
 
       <!-- TOC depthFrom:2 -->
+
       - [Features](#features)
         - [Blogging](#blogging)
         - [General](#general)
@@ -125,6 +132,7 @@ describe "EditTOC", ->
       - [Setup](#setup)
       - [Contributing](#contributing)
       - [Project](#project)
+
       <!-- /TOC -->
 
       ## Features


### PR DESCRIPTION
Add empty lines to TOC comment tags make them separated. To avoid some incompatibilities, e.g.

![image](https://user-images.githubusercontent.com/842419/49331903-66711800-f5df-11e8-9a48-8dbcf0cf3071.png)


