### PR TITLE
Handle different TabLength in edit-line commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.11.9
+
+- Use 2 spaces instead of TabLength in edit-line command ([#293](https://github.com/zhuochun/md-writer/issues/293))
+
 ## 2.11.8
 
 - Fix OL Indentation Alignment ([#274](https://github.com/zhuochun/md-writer/issues/274))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.11.9
 
-- Use 2 spaces instead of TabLength in edit-line command ([#293](https://github.com/zhuochun/md-writer/issues/293))
+- Improve edit-line command in different TabLength ([#293](https://github.com/zhuochun/md-writer/issues/293))
 
 ## 2.11.8
 

--- a/lib/commands/edit-line.coffee
+++ b/lib/commands/edit-line.coffee
@@ -156,7 +156,7 @@ class EditLine
       return
 
     if lineMeta.isList("ul")
-      bullet = config.get("templateVariables.ulBullet#{Math.round(currentIndentation)}")
+      bullet = @_ulBullet(@editor, currentIndentation)
       bullet = bullet || config.get("templateVariables.ulBullet") || lineMeta.defaultHead
 
       newline = "#{parentLineMeta.indentLineTabText()}#{lineMeta.lineHead(bullet)}#{lineMeta.body}"
@@ -181,6 +181,18 @@ class EditLine
   _isAtLineBeginning: (line, col) ->
     col == 0 || line.substring(0, col).trim() == ""
 
+  # FIXME this is a hack to handle different tab length. to fix we need to change to parse
+  # the complete list items to know the correct indentation and rewrite all logic in this file
+  _ulBullet: (editor, indentation) ->
+    label = ""
+    # best effort to be correct in the first 3 levels
+    if editor.getTabLength() <= 2
+      label = Math.floor(indentation)
+    else
+      label = Math.round(indentation)
+
+    config.get("templateVariables.ulBullet#{label}")
+
   undentListLine: (e, selection) ->
     return e.abortKeyBinding() if @_isRangeSelection(selection)
 
@@ -195,7 +207,7 @@ class EditLine
 
     parentLineMeta = @_findListLineBackward(cursor.row, currentIndentation)
     if !parentLineMeta && lineMeta.isList("ul")
-      bullet = config.get("templateVariables.ulBullet#{Math.round(currentIndentation-1)}")
+      bullet = @_ulBullet(@editor, currentIndentation-1)
       bullet = bullet || config.get("templateVariables.ulBullet") || lineMeta.defaultHead
 
       newline = "#{lineMeta.lineHead(bullet)}#{lineMeta.body}"

--- a/spec/commands/edit-line-spec.coffee
+++ b/spec/commands/edit-line-spec.coffee
@@ -353,6 +353,51 @@ describe "EditLine", ->
             "    + list line 3"
           ].join("\n")
 
+    describe "4-space tab unordered list", ->
+      beforeEach ->
+        atom.config.set("editor.tabLength", 4)
+
+        editor.setText [
+            "- list"
+            "- list line 2"
+            "  - list line 3"
+          ].join("\n")
+
+      it "pass 1st line", ->
+        editor.setCursorBufferPosition([0, 5])
+        editLine.trigger(event)
+        expect(event.abortKeyBinding).toHaveBeenCalled()
+
+      it "indent 2nd line", ->
+        editor.setCursorBufferPosition([1, 5])
+        editLine.trigger(event)
+        expect(editor.getText()).toBe [
+            "- list"
+            "  - list line 2"
+            "  - list line 3"
+          ].join("\n")
+        expect(editor.getCursorBufferPosition().toString()).toBe("(1, 7)")
+
+      it "indent 2nd line with ulBullet config", ->
+        atom.config.set("markdown-writer.templateVariables.ulBullet1", "*")
+        atom.config.set("markdown-writer.templateVariables.ulBullet2", "+")
+
+        editor.setCursorBufferPosition([1, 5])
+        editLine.trigger(event)
+        expect(editor.getText()).toBe [
+            "- list"
+            "  * list line 2"
+            "  - list line 3"
+          ].join("\n")
+
+        editor.setCursorBufferPosition([2, 5])
+        editLine.trigger(event)
+        expect(editor.getText()).toBe [
+            "- list"
+            "  * list line 2"
+            "    + list line 3"
+          ].join("\n")
+
     describe "ordered list", ->
       beforeEach ->
         editor.setText [


### PR DESCRIPTION
Changes:

- Handle different TabLength affects how list-indent should worked (#293)
- Refine on indentation check when TabLength == 4. Indentation for 2 spaces is 0.5 indentation  